### PR TITLE
Feature/change disable submit reload

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -31,7 +31,7 @@ export default class extends Controller {
     }
   }
 
-  extractVideoId() {
-    
+  extractVideoId(event) {
+    event.preventDefault();
   }
 }

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -2,11 +2,11 @@
   <!-- 1. The <iframe> (and video player) will replace this <div> tag. -->
   <div id="player"></div>
   <div>
-    <%= form_with(data: { controller: "youtube", action: "input->youtube#isValidSubmit"}) do |f| %>
+    <%= form_with(local: true, data: { controller: "youtube", action: "input->youtube#isValidSubmit submit->youtube#extractVideoId"}) do |f| %>
       <div>
         <%= f.url_field :url, class: "form-control", data: { youtube_target: "url", action: "input->youtube#url_validation" } %>
         <p data-youtube-target="error_url"></p>
-        <%= f.submit "submit" ,class: "bg-blue-500 text-white font-bold py-2 px-4 rounded", disabled: true, data: { youtube_target: "submit", action: "click->youtube#extractVideoId" } %>
+        <%= f.submit "submit" ,class: "bg-blue-500 text-white font-bold py-2 px-4 rounded", disabled: true, data: { youtube_target: "submit" } %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
# JPN
## 概要
Youtube動画のURLをフォームに入力してsubmitボタンを押した時に画面遷移してしまっていたので、画面遷移されないようにしました。

## 変更点
- event.preventDefault();の処理の追加
- 元々f.submitに配置されていたsubmit->youtube#extractVideoIdをform_withに移動（submit イベントはフォームにバインドされてるので、f.submitに対してstimulusのaction: submit→を記述しても発火しないから）
