### PR TITLE
Fix/disable submit logic

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -23,10 +23,10 @@ export default class extends Controller {
 
   isValidSubmit() {
     if(this.error_urlTarget.textContent == "" && this.urlTarget.value !== "") {
-      this.submitTarget.disabled = true
+      this.submitTarget.disabled = false
       this.submitTarget.className = "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
     } else {
-      this.submitTarget.disabled = false
+      this.submitTarget.disabled = true
       this.submitTarget.className = "bg-blue-500 text-white font-bold py-2 px-4 rounded"
     }
   }


### PR DESCRIPTION
# JPN
## 概要
youtube動画のURLのバリデーションに引っかかる時にボタンが有効になって、引っかからない時にボタンが無効になっていた。
これは想定している動作の逆であるため、trueとfalseを逆にすることで修正を行なった。

## 変更点
- disabledに対するtrue, falseの代入をそれぞれtrue -> false, false -> trueに変更した。

# EN
## Overviews
The submit button was being enabled when the YouTube video URL failed validation, and disabled when it passed.  Since this behavior was the opposite of what was intended, the condition was corrected by reversing the true/false logic.

## Changes
- Changed the values assigned to `disabled`: from true to false, and from false to true.