### PR TITLE
Feature/extract videoid from input youtube url

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -33,5 +33,9 @@ export default class extends Controller {
 
   extractVideoId(event) {
     event.preventDefault();
+    var youtubeVideoUrl = this.urlTarget.value
+    const urlRegex = /^.*(youtu\.be\/|v\/|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/
+    var match = youtubeVideoUrl.match(urlRegex)
+    videoId = match[5]
   }
 }


### PR DESCRIPTION
# JPN
## 概要
正規表現を用いてユーザーが入力したYoutube動画のURLのうち、videoIdの箇所を取り出し変数に格納する処理を実装しました。

# EN
## Overview
Added a process to extract the video ID from a Youtube video URL entered by the user and assign it to a variable.