### PR TITLE
Fix/rename function from extract video id to embed video

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -31,7 +31,7 @@ export default class extends Controller {
     }
   }
 
-  extractVideoId(event) {
+  embedVideo(event) {
     event.preventDefault();
     var youtubeVideoUrl = this.urlTarget.value
     const urlRegex = /^.*(youtu\.be\/|v\/|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -2,7 +2,7 @@
   <!-- 1. The <iframe> (and video player) will replace this <div> tag. -->
   <div id="player"></div>
   <div>
-    <%= form_with(local: true, data: { controller: "youtube", action: "input->youtube#isValidSubmit submit->youtube#extractVideoId"}) do |f| %>
+    <%= form_with(local: true, data: { controller: "youtube", action: "input->youtube#isValidSubmit submit->youtube#embedVideo"}) do |f| %>
       <div>
         <%= f.url_field :url, class: "form-control", data: { youtube_target: "url", action: "input->youtube#url_validation" } %>
         <p data-youtube-target="error_url"></p>


### PR DESCRIPTION
# JPN
## 概要
動画の埋め込みを実行するための関数を想定していたので、その手前の段階であるextractVideoIdという関数名は不正確であるため、embedVideoという関数名に変更しました。

## 変更点
- 関数extractVideoIdの関数名をembedVideoに変更

# EN
## Overview
extractVideoId is used for embedding a youtube video, so renamed the function name from extractVideoId to embedVideo.

## Changes
- renamed the function name from extractVideoId to embedVideo.