### PR TITLE
Feature/embed the other video

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -4,7 +4,8 @@ export default class extends Controller {
   static targets = [ 
                     "url",
                     "error_url",
-                    "submit"
+                    "submit",
+                    "frame"
   ]
 
   initialize() {
@@ -42,17 +43,32 @@ export default class extends Controller {
   embedVideo(event) {
     event.preventDefault();
     var youtubeVideoUrl = this.urlTarget.value
+    const DivNotEmbeddedYet = new DOMParser().parseFromString('<div id="player" data-youtube-target="frame"></div>', "text/html").querySelector('#player')
     const urlRegex = /^.*(youtu\.be\/|v\/|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/
     var match = youtubeVideoUrl.match(urlRegex)
     const extractedVideoId = match[5]
 
-    let player = new YT.Player('player', {
-      height: '390',
-      width: '640',
-      videoId: extractedVideoId,
-      playerVars: {
-        'playsinline': 1
-      }
-    });
+    console.log(DivNotEmbeddedYet)
+
+    if(this.frameTarget.tagName == "DIV") {
+      let player = new YT.Player('player', {
+        height: '390',
+        width: '640',
+        videoId: extractedVideoId,
+        playerVars: {
+          'playsinline': 1
+        }
+      });
+    } else {
+      this.frameTarget.replaceWith(DivNotEmbeddedYet)
+      let player = new YT.Player('player', {
+        height: '390',
+        width: '640',
+        videoId: extractedVideoId,
+        playerVars: {
+          'playsinline': 1
+        }
+      });
+    }
   }
 }

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,13 +1,15 @@
 <div>
   <!-- 1. The <iframe> (and video player) will replace this <div> tag. -->
-  <div id="player"></div>
-  <div>
-    <%= form_with(local: true, data: { controller: "youtube", action: "input->youtube#isValidSubmit submit->youtube#embedVideo"}) do |f| %>
-      <div>
-        <%= f.url_field :url, class: "form-control", data: { youtube_target: "url", action: "input->youtube#url_validation" } %>
-        <p data-youtube-target="error_url"></p>
-        <%= f.submit "submit" ,class: "bg-blue-500 text-white font-bold py-2 px-4 rounded", disabled: true, data: { youtube_target: "submit" } %>
-      </div>
-    <% end %>
+  <div data-controller="youtube">
+    <div id="player" data-youtube-target="frame"></div>
+    <div>
+      <%= form_with(local: true, data: { action: "input->youtube#isValidSubmit submit->youtube#embedVideo"}) do |f| %>
+        <div>
+          <%= f.url_field :url, class: "form-control", data: { youtube_target: "url", action: "input->youtube#url_validation" } %>
+          <p data-youtube-target="error_url"></p>
+          <%= f.submit "submit" ,class: "bg-blue-500 text-white font-bold py-2 px-4 rounded", disabled: true, data: { youtube_target: "submit" } %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
既に動画が埋め込まれている状態で、別の動画のURLをsubmitしても更新されなかったので、別の動画のURLをsubmitするとその動画に置き換わるような処理を実装しました。

## 変更点
- stimulusを用いて動画埋め込みのerbの箇所のターゲット(対象: "frame")を追加
- 動画が埋め込まれていない状態のdivタグ及びその内容を、定数DivNotEmbeddedYetに格納する処理の追加
- 動画が既に埋め込まれている場合に、定数DivNotEmbeddedYetに置き換えることで動画が埋め込まれていない状態に更新する処理を追加
- 新しく更新したい動画が埋め込まれる処理を追加

## 確認方法
1. トップページにアクセス
2. URL①を入力
3. ボタンをクリック
4. URL①の動画が埋め込まれる
5. URL②を入力
6. ボタンをクリック
7. URL①の動画の表示が消えて、URL②の動画が表示されるように更新されます