### PR TITLE
Fix/ignore keydown on input form

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -70,7 +70,8 @@ export default class extends Controller {
     }
   }
 
-  play() {
+  play(event) {
+    if(event.target.closest(".ignore-keydown")) return
     console.log("再生します")
   }
 }

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -4,7 +4,7 @@
     <div>
       <%= form_with(local: true, data: { action: "input->youtube#isValidSubmit submit->youtube#embedVideo"}) do |f| %>
         <div>
-          <%= f.url_field :url, class: "form-control", data: { youtube_target: "url", action: "input->youtube#url_validation" } %>
+          <%= f.url_field :url, class: "form-control ignore-keydown",data: { youtube_target: "url", action: "input->youtube#url_validation" } %>
           <p data-youtube-target="error_url"></p>
           <%= f.submit "submit" ,class: "bg-blue-500 text-white font-bold py-2 px-4 rounded", disabled: true, data: { youtube_target: "submit" } %>
         </div>
@@ -17,7 +17,7 @@
     </div>
     <div>
       <div>
-        <input type="time" class="icon-del font-bold">
+        <input type="time" class="icon-del font-bold ignore-keydown">
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
youtube動画URLを入力するinputフォームと、秒数を入力するinputフォームに対してTキーを打鍵するとplay()が実行されるようになってしまっていたため、youtube動画URLを入力するinputフォームと、秒数を入力するinputフォームに対してTキーを打鍵してもplay()が実行されないように修正しました。

## 変更点
- ignore-keydownのclassを持つ要素からのイベントが発火した場合に処理を中断します
- play()を実行させたくない要素に対してignore-keydownというclassを付与しました