### PR TITLE
Fix/try play function with no embed

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -90,6 +90,7 @@ export default class extends Controller {
 
   play(event) {
     if(event.target.closest(".ignore-keydown")) return
+    if(this.frameTarget.tagName == "DIV") return
 
     const [m,s] = this.targetTime(event).value.split(":")
     const minSecArray = [m,s].map( str => parseInt(str, 10))


### PR DESCRIPTION
## 概要
動画が埋め込まれていない状態でplay()をキー打鍵で実行するとエラーが発生していたので、動画が埋め込まれていない状態でplay()を実行しようとすると、処理の初めに関数の実行を終了するようにしました。

## 変更点
- iFrameが埋め込まれる箇所が<div>(埋め込まれていない時の初期状態)である場合、実行を終了するような処理を追加しました