### PR TITLE
Fix/pad click not playing video

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -107,6 +107,15 @@ export default class extends Controller {
       this.getPlayer.seekTo(totalSecondResult, true)
       this.getPlayer.playVideo()
     }
+
+    if(event.type == "click") {
+      const [m,s] = this.targetTime(event).value.split(":")
+      const minSecArray = [m,s].map( str => parseInt(str, 10))
+      const totalSecondResult = minSecArray[0]*60 + minSecArray[1]
+
+      this.getPlayer.seekTo(totalSecondResult, true)
+      this.getPlayer.playVideo()
+    }
   }
 
   targetTime(event) {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -99,23 +99,12 @@ export default class extends Controller {
     if(event.target.closest(".ignore-keydown")) return
     if(this.frameTarget.tagName == "DIV") return
 
-    if(event.type == "keydown") {
       const [m,s] = this.targetTime(event).value.split(":")
       const minSecArray = [m,s].map( str => parseInt(str, 10))
       const totalSecondResult = minSecArray[0]*60 + minSecArray[1]
 
       this.getPlayer.seekTo(totalSecondResult, true)
       this.getPlayer.playVideo()
-    }
-
-    if(event.type == "click") {
-      const [m,s] = this.targetTime(event).value.split(":")
-      const minSecArray = [m,s].map( str => parseInt(str, 10))
-      const totalSecondResult = minSecArray[0]*60 + minSecArray[1]
-
-      this.getPlayer.seekTo(totalSecondResult, true)
-      this.getPlayer.playVideo()
-    }
   }
 
   targetTime(event) {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -130,6 +130,14 @@ export default class extends Controller {
     if(event.key == "m") return this.m_start_timeTarget
 
     if(event.target.id == "t_pad") return this.t_start_timeTarget
+    if(event.target.id == "y_pad") return this.y_start_timeTarget
+    if(event.target.id == "u_pad") return this.u_start_timeTarget
+    if(event.target.id == "g_pad") return this.g_start_timeTarget
+    if(event.target.id == "h_pad") return this.h_start_timeTarget
+    if(event.target.id == "j_pad") return this.j_start_timeTarget
+    if(event.target.id == "b_pad") return this.b_start_timeTarget
+    if(event.target.id == "n_pad") return this.n_start_timeTarget
+    if(event.target.id == "m_pad") return this.m_start_timeTarget
   }
 
   get getPlayer() {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -99,12 +99,12 @@ export default class extends Controller {
     if(event.target.closest(".ignore-keydown")) return
     if(this.frameTarget.tagName == "DIV") return
 
-      const [m,s] = this.targetTime(event).value.split(":")
-      const minSecArray = [m,s].map( str => parseInt(str, 10))
-      const totalSecondResult = minSecArray[0]*60 + minSecArray[1]
+    const [m,s] = this.targetTime(event).value.split(":")
+    const minSecArray = [m,s].map( str => parseInt(str, 10))
+    const totalSecondResult = minSecArray[0]*60 + minSecArray[1]
 
-      this.getPlayer.seekTo(totalSecondResult, true)
-      this.getPlayer.playVideo()
+    this.getPlayer.seekTo(totalSecondResult, true)
+    this.getPlayer.playVideo()
   }
 
   targetTime(event) {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -99,12 +99,14 @@ export default class extends Controller {
     if(event.target.closest(".ignore-keydown")) return
     if(this.frameTarget.tagName == "DIV") return
 
-    const [m,s] = this.targetTime(event).value.split(":")
-    const minSecArray = [m,s].map( str => parseInt(str, 10))
-    const totalSecondResult = minSecArray[0]*60 + minSecArray[1]
+    if(event.type == "keydown") {
+      const [m,s] = this.targetTime(event).value.split(":")
+      const minSecArray = [m,s].map( str => parseInt(str, 10))
+      const totalSecondResult = minSecArray[0]*60 + minSecArray[1]
 
-    this.getPlayer.seekTo(totalSecondResult, true)
-    this.getPlayer.playVideo()
+      this.getPlayer.seekTo(totalSecondResult, true)
+      this.getPlayer.playVideo()
+    }
   }
 
   targetTime(event) {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -119,6 +119,8 @@ export default class extends Controller {
     if(event.key == "b") return this.b_start_timeTarget
     if(event.key == "n") return this.n_start_timeTarget
     if(event.key == "m") return this.m_start_timeTarget
+
+    if(event.target.id == "t_pad") return this.t_start_timeTarget
   }
 
   get getPlayer() {

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -22,7 +22,7 @@
     </div>
     <div class="flex">
       <div>
-        <div data-action="click->youtube#play" class="border border-black bg-green-100 aspect-square w-20">
+        <div data-action="click->youtube#play" id="t_pad" class="border border-black bg-green-100 aspect-square w-20">
           <div>
             <p>key:T</p>
           </div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -34,7 +34,7 @@
         </div>
       </div>
       <div>
-        <div data-action="click->youtube#play" class="border border-black bg-green-100 aspect-square w-20">
+        <div data-action="click->youtube#play" id="y_pad" class="border border-black bg-green-100 aspect-square w-20">
           <div>
             <p>key:Y</p>
           </div>
@@ -46,7 +46,7 @@
         </div>
       </div>
       <div>
-        <div data-action="click->youtube#play" class="border border-black bg-green-100 aspect-square w-20">
+        <div data-action="click->youtube#play" id="u_pad" class="border border-black bg-green-100 aspect-square w-20">
           <div>
             <p>key:U</p>
           </div>
@@ -58,7 +58,7 @@
         </div>
       </div>
       <div>
-        <div data-action="click->youtube#play" class="border border-black bg-green-100 aspect-square w-20">
+        <div data-action="click->youtube#play" id="g_pad" class="border border-black bg-green-100 aspect-square w-20">
           <div>
             <p>key:G</p>
           </div>
@@ -70,7 +70,7 @@
         </div>
       </div>
       <div>
-        <div data-action="click->youtube#play" class="border border-black bg-green-100 aspect-square w-20">
+        <div data-action="click->youtube#play" id="h_pad" class="border border-black bg-green-100 aspect-square w-20">
           <div>
             <p>key:H</p>
           </div>
@@ -82,7 +82,7 @@
         </div>
       </div>
       <div>
-        <div data-action="click->youtube#play" class="border border-black bg-green-100 aspect-square w-20">
+        <div data-action="click->youtube#play" id="j_pad" class="border border-black bg-green-100 aspect-square w-20">
           <div>
             <p>key:J</p>
           </div>
@@ -94,7 +94,7 @@
         </div>
       </div>
       <div>
-        <div data-action="click->youtube#play" class="border border-black bg-green-100 aspect-square w-20">
+        <div data-action="click->youtube#play" id="b_pad" class="border border-black bg-green-100 aspect-square w-20">
           <div>
             <p>key:B</p>
           </div>
@@ -106,7 +106,7 @@
         </div>
       </div>
       <div>
-        <div data-action="click->youtube#play" class="border border-black bg-green-100 aspect-square w-20">
+        <div data-action="click->youtube#play" id="n_pad" class="border border-black bg-green-100 aspect-square w-20">
           <div>
             <p>key:N</p>
           </div>
@@ -118,7 +118,7 @@
         </div>
       </div>
       <div>
-        <div data-action="click->youtube#play" class="border border-black bg-green-100 aspect-square w-20">
+        <div data-action="click->youtube#play" id="m_pad" class="border border-black bg-green-100 aspect-square w-20">
           <div>
             <p>key:M</p>
           </div>


### PR DESCRIPTION
## 概要
パッドが複数個になったことで各パッドと各`input time`の対応が取れていなかった。

そこで、各パッドにユニークなidを割り当てて、イベントがあったパッドのidから、そのパッドと関係する`input time`のターゲットを返してあげることで、各パッドが各`input time`と対応が取れ、パッドをクリックすると対応した`input time`の時間を抜き出してその時間からの動画再生の処理が走るように修正しました。

## 変更点
- 各パッドにユニークなidを割り当てました
- イベントが発生したターゲットのidから、対応した`input time`のターゲットを返すような処理を新規作成しました