### PR TITLE
Feature/play sequencer with selected samples

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -68,7 +68,7 @@ export default class extends Controller {
     const players = new Tone.Players({
       chop  : '/samples/snares/boom-bap-snare.wav',
       hihat : this.fetchSampleSoundPath(this.current_hihatTarget.textContent),
-      snare : '/samples/snares/boom-bap-snare.wav',
+      snare : this.fetchSampleSoundPath(this.current_snareTarget.textContent),
       kick  : '/samples/kicks/drum-boom-bap-kick_C_minor.wav'
     }).toDestination();
   

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -50,7 +50,7 @@ export default class extends Controller {
   }
 
   playSampleDemo(event) {
-    const player = new Tone.Player(this.fetchSampleSoundPath(event)).toDestination();
+    const player = new Tone.Player(this.fetchSampleSoundPath(event, null)).toDestination();
     player.autostart = true;    
   }
 
@@ -67,7 +67,7 @@ export default class extends Controller {
   
     const players = new Tone.Players({
       chop  : '/samples/snares/boom-bap-snare.wav',
-      hihat : "/samples/hihats/short-bouncy-hi-hat-one-shot_C_minor.wav",
+      hihat : this.fetchSampleSoundPath(null, this.current_hihatTarget.textContent),
       snare : '/samples/snares/boom-bap-snare.wav',
       kick  : '/samples/kicks/drum-boom-bap-kick_C_minor.wav'
     }).toDestination();
@@ -92,7 +92,7 @@ export default class extends Controller {
   }
   
 
-  fetchSampleSoundPath(event) {
+  fetchSampleSoundPath(event, current_sample_name) {
     const sample_name = event.target.parentNode.previousElementSibling.textContent
     if (sample_name.includes('hihat')) {
       if(sample_name.includes('#1')) return "/samples/hihats/short-bouncy-hi-hat-one-shot_C_minor.wav"

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -64,16 +64,9 @@ export default class extends Controller {
       grid_array.slice(32,48),  // snare
       grid_array.slice(48,64)   // kick
     ];
-  
-    const players = new Tone.Players({
-      chop  : '/samples/snares/boom-bap-snare.wav',
-      hihat : this.fetchSampleSoundPath(this.current_hihatTarget.textContent),
-      snare : this.fetchSampleSoundPath(this.current_snareTarget.textContent),
-      kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)
-    }).toDestination();
-  
+
     let beat = 0;
-  
+
     Tone.Transport.scheduleRepeat((time) => {
       rows.forEach((row, index) => {
         const step = row[beat];
@@ -87,10 +80,16 @@ export default class extends Controller {
     }, "16n");
 
     Tone.Transport.bpm.value = Number(this.current_bpmTarget.textContent)
-  
-    Tone.Transport.start();
+
+    const players = new Tone.Players({
+      chop  : '/samples/snares/boom-bap-snare.wav',
+      hihat : this.fetchSampleSoundPath(this.current_hihatTarget.textContent),
+      snare : this.fetchSampleSoundPath(this.current_snareTarget.textContent),
+      kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)
+    }, function() {
+      Tone.Transport.start()
+    }).toDestination();
   }
-  
 
   fetchSampleSoundPath(input) {
     let sample_name

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -69,7 +69,7 @@ export default class extends Controller {
       chop  : '/samples/snares/boom-bap-snare.wav',
       hihat : this.fetchSampleSoundPath(this.current_hihatTarget.textContent),
       snare : this.fetchSampleSoundPath(this.current_snareTarget.textContent),
-      kick  : '/samples/kicks/drum-boom-bap-kick_C_minor.wav'
+      kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)
     }).toDestination();
   
     let beat = 0;

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -92,8 +92,14 @@ export default class extends Controller {
   }
   
 
-  fetchSampleSoundPath(event) {
-    const sample_name = event.target.parentNode.previousElementSibling.textContent
+  fetchSampleSoundPath(input) {
+    let sample_name
+    
+    if (input instanceof Event) {
+      sample_name = input.target.parentNode.previousElementSibling.textContent
+    } else {
+      sample_name = input
+    }
     
     if (sample_name.includes('hihat')) {
       if(sample_name.includes('#1')) return "/samples/hihats/short-bouncy-hi-hat-one-shot_C_minor.wav"

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -50,7 +50,7 @@ export default class extends Controller {
   }
 
   playSampleDemo(event) {
-    const player = new Tone.Player(this.fetchSampleSoundPath(event, null)).toDestination();
+    const player = new Tone.Player(this.fetchSampleSoundPath(event)).toDestination();
     player.autostart = true;    
   }
 
@@ -67,7 +67,7 @@ export default class extends Controller {
   
     const players = new Tone.Players({
       chop  : '/samples/snares/boom-bap-snare.wav',
-      hihat : this.fetchSampleSoundPath(null, this.current_hihatTarget.textContent),
+      hihat : this.fetchSampleSoundPath(this.current_hihatTarget.textContent),
       snare : '/samples/snares/boom-bap-snare.wav',
       kick  : '/samples/kicks/drum-boom-bap-kick_C_minor.wav'
     }).toDestination();
@@ -92,8 +92,9 @@ export default class extends Controller {
   }
   
 
-  fetchSampleSoundPath(event, current_sample_name) {
+  fetchSampleSoundPath(event) {
     const sample_name = event.target.parentNode.previousElementSibling.textContent
+    
     if (sample_name.includes('hihat')) {
       if(sample_name.includes('#1')) return "/samples/hihats/short-bouncy-hi-hat-one-shot_C_minor.wav"
       if(sample_name.includes('#2')) return "/samples/hihats/aggressive-short-hi-hat-one-shot.wav"


### PR DESCRIPTION
## 概要
固定されたサンプルを鳴らすのではなく、選択されたサンプルがシークエンサー実行時に鳴るようにアップデートしました

## 変更点
- サンプルがロードされる前にプレイボタンを押すと動作自体は問題はないものの、`Uncaught Error: buffer is either not set or not loaded`と開発者コンソールに表示されていたので、`Tone.Transport.start()`を`Tone.Players`の第二引数に取ることでロード完了後にシークエンサーがプレイ開始されるように変更
- wavファイルのパスをfetchする関数`fetchSampleSoundPath(input)`がクリックイベントの場合とコントローラー内から呼び出す場合の二つの呼び出し方が発生しており実行が出来ていなかったので、分岐処理を追加して引数の`input`がクリックイベントかどうかを判別してそれに応じて変数に代入する値を変えるように変更