### PR TITLE
Feature/add stop sequencer

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -67,7 +67,7 @@ export default class extends Controller {
 
     let beat = 0;
 
-    Tone.Transport.scheduleRepeat((time) => {
+    await Tone.Transport.scheduleRepeat((time) => {
       rows.forEach((row, index) => {
         const step = row[beat];
         if (step.dataset.active === "true") {
@@ -88,7 +88,12 @@ export default class extends Controller {
       kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)
     }, function() {
       Tone.Transport.start()
-    }).toDestination();
+    }).toDestination()
+  }
+
+  stopSequencer() {
+    Tone.Transport.stop()
+    Tone.Transport.cancel()
   }
 
   fetchSampleSoundPath(input) {

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -8,7 +8,7 @@
         </div>
         <input type="range" id="bpm" min="60" max="240" value="90" data-action="input->step-sequencer#currentBPM" data-step-sequencer-target="bpm">
         <button class="bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#playSequencer">Play</button>
-        <button class="bg-blue-500 text-white font-bold py-2 px-4 rounded">Stop</button>
+        <button class="bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#stopSequencer">Stop</button>
       </div>
     </div>
     <div class="flex items-center justify-center">

--- a/step-sequencer#stopSequencer to stop button
+++ b/step-sequencer#stopSequencer to stop button
@@ -1,0 +1,2 @@
+[feature/add-stop-sequencer d1e97d6] [add] data-action=click-
+ 1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
## 概要
`Stop`ボタンを押すとシーケンサーが中断されるような処理を実装しました。

## 変更点
- `Stop`ボタンの`button`タグに`data-action="click->step-sequencer#stopSequencer"`を追加
- `stopSequencer()`を新規作成
- `Tone.Tranport.stop()`で停止し、`Tone.Tranport.cancel()`で`Tone.Transport.scheduleRepeat`で作成されたイベントを削除する処理を実装

## 確認方法

1. トップページにアクセス
2. 各サンプルを選択
3. 適当にステップをクリックしていくつかアクティブにします
4. `Play`ボタンをクリックしてシーケンサーを実行
5. `Stop`ボタンをクリックするとシーケンサーが中断されることが確認できます
6. もう一度`Play`ボタンを押すといちからシーケンサーが実行されることが確認できます