### PR TITLE
Fix/executable play button in already playing

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -92,6 +92,8 @@ export default class extends Controller {
     }, function() {
       Tone.Transport.start()
     }).toDestination()
+
+    this.isPlaying = true
   }
 
   stopSequencer() {

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -97,6 +97,7 @@ export default class extends Controller {
   stopSequencer() {
     Tone.Transport.stop()
     Tone.Transport.cancel()
+    this.isPlaying = false
   }
 
   highlightStep(beat) {

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -56,6 +56,8 @@ export default class extends Controller {
   }
 
   async playSequencer() {
+    if (this.isPlaying) { return }
+
     await Tone.start();
   
     const grid_array = Array.from(this.gridTarget.children);

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -56,7 +56,7 @@ export default class extends Controller {
   }
 
   async playSequencer() {
-    if (this.isPlaying) { return }
+    if (this.isPlaying)  return
 
     await Tone.start();
   


### PR DESCRIPTION
## 概要
既にシークエンサーが実行されて音が鳴っている状態で`Play`ボタンを押せるようになっており、そうすると押した回数分だけ音が何重にも重なっていくことになるので、`isPlaying(:boolean)`の変数でプレイの状態を管理し、`true`の場合は既に実行されているということなので、`true`の場合は`playSequencer`の最初の行で実行を中断するように修正しました。

## 変更点
- `playSequencer()`を実行すると`isPlaying`に`true`が代入される
- `stopSequencer()`を実行すると`isPlaying`に`false`が代入される
- `playSequencer()`の最初の行に`this.isPlaying`が`true`なら中断する処理を追加