### PR TITLE
Feature/add pause youtube on the set time

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -107,9 +107,9 @@ export default class extends Controller {
     const [m,s] = this.targetTime(event).start.value.split(":")
     const startTimeMinSec = [m,s]
     const startTimeDecimalStr = this.targetTime(event).start_decimal.value
-    const firstDecimalNum = Number('0.' + startTimeDecimalStr)
+    const startTimeDecimalNum = Number('0.' + startTimeDecimalStr)
     const minSecArray = startTimeMinSec.map( str => parseInt(str, 10))
-    const totalSecondResult = minSecArray[0]*60 + minSecArray[1] + firstDecimalNum
+    const totalSecondResult = minSecArray[0]*60 + minSecArray[1] + startTimeDecimalNum
 
     this.getPlayer.seekTo(totalSecondResult, true)
     this.getPlayer.playVideo()

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -10,6 +10,7 @@ export default class extends Controller {
                     "range",
                     "t_start_time",
                     "t_start_time_decimal",
+                    "t_end_time",
                     "y_start_time",
                     "u_start_time",
                     "g_start_time",

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -112,6 +112,8 @@ export default class extends Controller {
     const startTimeMinSecArray = startTimeMinSec.map( str => parseInt(str, 10))
     const startTimeTotalSecond = startTimeMinSecArray[0]*60 + startTimeMinSecArray[1] + startTimeDecimalNum
 
+    const [end_m,end_s] = this.targetTime(event).end.value.split(":")
+
     this.getPlayer.seekTo(startTimeTotalSecond, true)
     this.getPlayer.playVideo()
   }

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -108,8 +108,8 @@ export default class extends Controller {
     const startTimeMinSec = [m,s]
     const startTimeDecimalStr = this.targetTime(event).start_decimal.value
     const startTimeDecimalNum = Number('0.' + startTimeDecimalStr)
-    const minSecArray = startTimeMinSec.map( str => parseInt(str, 10))
-    const totalSecondResult = minSecArray[0]*60 + minSecArray[1] + startTimeDecimalNum
+    const startTimeMinSecArray = startTimeMinSec.map( str => parseInt(str, 10))
+    const totalSecondResult = startTimeMinSecArray[0]*60 + startTimeMinSecArray[1] + startTimeDecimalNum
 
     this.getPlayer.seekTo(totalSecondResult, true)
     this.getPlayer.playVideo()

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -112,10 +112,13 @@ export default class extends Controller {
     const startTimeMinSecArray = startTimeMinSec.map( str => parseInt(str, 10))
     const startTimeTotalSecond = startTimeMinSecArray[0]*60 + startTimeMinSecArray[1] + startTimeDecimalNum
 
+    // end time
     const [end_m,end_s] = this.targetTime(event).end.value.split(":")
     const endTimeMinSec = [end_m,end_s]
     const endTimeDecimalStr = this.targetTime(event).end_decimal.value
     const endTimeDecimalNum = Number('0.' + endTimeDecimalStr)
+    const endTimeMinSecArray = endTimeMinSec.map( str => parseInt(str, 10))
+    const endTimeTotalSecond = endTimeMinSecArray[0]*60 + endTimeMinSecArray[1] + endTimeDecimalNum
 
     this.getPlayer.seekTo(startTimeTotalSecond, true)
     this.getPlayer.playVideo()

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -114,6 +114,7 @@ export default class extends Controller {
 
     const [end_m,end_s] = this.targetTime(event).end.value.split(":")
     const endTimeMinSec = [end_m,end_s]
+    const endTimeDecimalStr = this.targetTime(event).end_decimal.value
 
     this.getPlayer.seekTo(startTimeTotalSecond, true)
     this.getPlayer.playVideo()

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -104,6 +104,7 @@ export default class extends Controller {
     if(event.target.closest(".ignore-keydown")) return
     if(this.frameTarget.tagName == "DIV") return
 
+    // start time
     const [m,s] = this.targetTime(event).start.value.split(":")
     const startTimeMinSec = [m,s]
     const startTimeDecimalStr = this.targetTime(event).start_decimal.value

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -115,6 +115,7 @@ export default class extends Controller {
     const [end_m,end_s] = this.targetTime(event).end.value.split(":")
     const endTimeMinSec = [end_m,end_s]
     const endTimeDecimalStr = this.targetTime(event).end_decimal.value
+    const endTimeDecimalNum = Number('0.' + endTimeDecimalStr)
 
     this.getPlayer.seekTo(startTimeTotalSecond, true)
     this.getPlayer.playVideo()

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -109,9 +109,9 @@ export default class extends Controller {
     const startTimeDecimalStr = this.targetTime(event).start_decimal.value
     const startTimeDecimalNum = Number('0.' + startTimeDecimalStr)
     const startTimeMinSecArray = startTimeMinSec.map( str => parseInt(str, 10))
-    const totalSecondResult = startTimeMinSecArray[0]*60 + startTimeMinSecArray[1] + startTimeDecimalNum
+    const startTimeTotalSecond = startTimeMinSecArray[0]*60 + startTimeMinSecArray[1] + startTimeDecimalNum
 
-    this.getPlayer.seekTo(totalSecondResult, true)
+    this.getPlayer.seekTo(startTimeTotalSecond, true)
     this.getPlayer.playVideo()
   }
 

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -106,9 +106,9 @@ export default class extends Controller {
 
     const [m,s] = this.targetTime(event).start.value.split(":")
     const startTimeMinSec = [m,s]
-    const firstDecimalStr = this.targetTime(event).start_decimal.value
+    const startTimeDecimalStr = this.targetTime(event).start_decimal.value
+    const firstDecimalNum = Number('0.' + startTimeDecimalStr)
     const minSecArray = startTimeMinSec.map( str => parseInt(str, 10))
-    const firstDecimalNum = Number('0.' + firstDecimalStr)
     const totalSecondResult = minSecArray[0]*60 + minSecArray[1] + firstDecimalNum
 
     this.getPlayer.seekTo(totalSecondResult, true)

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -116,10 +116,10 @@ export default class extends Controller {
 
   targetTime(event) {
     if(event.key == "t") return {
-      start: this.t_start_timeTarget, 
-      start_decimal: this.t_start_time_decimalTarget,
-      end: this.t_end_timeTarget,
-      end_decimal: this.t_end_time_decimalTarget
+      start:          this.t_start_timeTarget, 
+      start_decimal:  this.t_start_time_decimalTarget,
+      end:            this.t_end_timeTarget,
+      end_decimal:    this.t_end_time_decimalTarget
     }
     if(event.key == "y") return this.y_start_timeTarget
     if(event.key == "u") return this.u_start_timeTarget

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -119,6 +119,7 @@ export default class extends Controller {
       start: this.t_start_timeTarget, 
       start_decimal: this.t_start_time_decimalTarget,
       end: this.t_end_timeTarget,
+      end_decimal: this.t_end_time_decimalTarget
     }
     if(event.key == "y") return this.y_start_timeTarget
     if(event.key == "u") return this.u_start_timeTarget

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -105,8 +105,9 @@ export default class extends Controller {
     if(this.frameTarget.tagName == "DIV") return
 
     const [m,s] = this.targetTime(event).start.value.split(":")
+    const startTimeMinSec = [m,s]
     const firstDecimalStr = this.targetTime(event).start_decimal.value
-    const minSecArray = [m,s].map( str => parseInt(str, 10))
+    const minSecArray = startTimeMinSec.map( str => parseInt(str, 10))
     const firstDecimalNum = Number('0.' + firstDecimalStr)
     const totalSecondResult = minSecArray[0]*60 + minSecArray[1] + firstDecimalNum
 

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -115,7 +115,11 @@ export default class extends Controller {
   }
 
   targetTime(event) {
-    if(event.key == "t") return {start: this.t_start_timeTarget, start_decimal: this.t_start_time_decimalTarget}
+    if(event.key == "t") return {
+      start: this.t_start_timeTarget, 
+      start_decimal: this.t_start_time_decimalTarget,
+      end: this.t_end_timeTarget,
+    }
     if(event.key == "y") return this.y_start_timeTarget
     if(event.key == "u") return this.u_start_timeTarget
     if(event.key == "g") return this.g_start_timeTarget

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
                     "t_start_time",
                     "t_start_time_decimal",
                     "t_end_time",
+                    "t_end_time_decimal",
                     "y_start_time",
                     "u_start_time",
                     "g_start_time",

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -120,6 +120,9 @@ export default class extends Controller {
     const endTimeMinSecArray = endTimeMinSec.map( str => parseInt(str, 10))
     const endTimeTotalSecond = endTimeMinSecArray[0]*60 + endTimeMinSecArray[1] + endTimeDecimalNum
 
+    // playing length
+    const playingTimeTotalSecond = endTimeTotalSecond - endTimeTotalSecond
+
     this.getPlayer.seekTo(startTimeTotalSecond, true)
     this.getPlayer.playVideo()
   }

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -121,10 +121,13 @@ export default class extends Controller {
     const endTimeTotalSecond = endTimeMinSecArray[0]*60 + endTimeMinSecArray[1] + endTimeDecimalNum
 
     // playing length
-    const playingTimeTotalSecond = endTimeTotalSecond - endTimeTotalSecond
+    const playingTimeTotalSecond = endTimeTotalSecond - startTimeTotalSecond
 
     this.getPlayer.seekTo(startTimeTotalSecond, true)
     this.getPlayer.playVideo()
+    setTimeout(() => {
+      this.getPlayer.pauseVideo()
+    }, playingTimeTotalSecond * 1000)
   }
 
   targetTime(event) {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -113,6 +113,7 @@ export default class extends Controller {
     const startTimeTotalSecond = startTimeMinSecArray[0]*60 + startTimeMinSecArray[1] + startTimeDecimalNum
 
     const [end_m,end_s] = this.targetTime(event).end.value.split(":")
+    const endTimeMinSec = [end_m,end_s]
 
     this.getPlayer.seekTo(startTimeTotalSecond, true)
     this.getPlayer.playVideo()

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -6,9 +6,9 @@
         <div>
           <button id="dropdownHoverButton" data-dropdown-toggle="dropdownHover" data-dropdown-trigger="hover" class="border border-black bg-gray-100 aspect-square w-full" type="button">
             <div>
-              <div>00:00.0</div>
+              <div>-- : --.-</div>
               <div>〜</div>
-              <div>00:00.0</div>
+              <div>-- : --.-</div>
             </div> 
           </button>
           <!-- T pad Dropdown menu -->

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -8,7 +8,7 @@
           </button>
 
           <!-- T pad Dropdown menu -->
-          <div id="dropdownHover" class="z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
+          <div id="dropdownHover" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
               <div class="flex items-center justify-center">
                 <div class="flex items-end">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -24,7 +24,7 @@
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="t_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -5,8 +5,12 @@
         <!-- T pad -->
         <div>
           <button id="dropdownHoverButton" data-dropdown-toggle="dropdownHover" data-dropdown-trigger="hover" class="border border-black bg-gray-100 aspect-square w-full" type="button">
+            <div>
+              <div>00:00.0</div>
+              <div>〜</div>
+              <div>00:00.0</div>
+            </div> 
           </button>
-
           <!-- T pad Dropdown menu -->
           <div id="dropdownHover" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -28,7 +28,7 @@
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="t_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 概要
従来は再生開始地点のみの指定しか出来なかったので再生停止地点の指定を出来るようにした。
こうすることで、パッドに対応したキーを打鍵するだけで、**「指定した再生開始地点から再生を開始して、指定した再生停止地点で停止する」**という処理を行えるように処理を加えた。

つまり範囲を指定できるようになったということなので、よりサンプラーのチョップ機能に近い形の処理が実現したことになる。

## 変更点
- 再生停止地点の`input`をそれぞれターゲットに指定した -> `"t_end_time", "t_end_time_decimal",`
- 再生開始に関する変数と再生停止に関する変数の区別がつきやすいように変数名を一部変更
- 再生停止に関する変数の追加
- 再生停止までの処理を追加（`setTimeout()`を使うことで再生停止地点まで処理を待機させている）
- Tキー打鍵をした時に`"t_end_time", "t_end_time_decimal"`を含めたオブジェクトを返すようにするために`targetTime(event)`内に`"t_end_time", "t_end_time_decimal"`を追加