### PR TITLE
Fix/stop past set pause timing

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -104,6 +104,7 @@ export default class extends Controller {
   }
 
   play(event) {
+    clearTimeout(this.timeoutId_)
     if(event.target.closest(".ignore-keydown")) return
     if(this.frameTarget.tagName == "DIV") return
 
@@ -128,7 +129,7 @@ export default class extends Controller {
 
     this.getPlayer.seekTo(startTimeTotalSecond, true)
     this.getPlayer.playVideo()
-    setTimeout(() => {
+    this.timeoutId_ = setTimeout(() => {
       this.getPlayer.pauseVideo()
     }, playingTimeTotalSecond * 1000)
   }


### PR DESCRIPTION
## 概要
`play()`を実行した以降で`play()`を実行した場合に、過去の`setTimeout()`が中断されない結果として過去の`setTimeout()`で指定された待機時間を終えたら`pauseVideo()`で動画が停止するようになってしまっていた。

よって、`setTimeout()`で待機している途中に次の`play()`を実行した時に、前回の`setTimeout()`の処理は中断されるように修正しました。

## 変更点
- `setTimeout()`をメンバ変数`this.timeoutId_`に代入
- `play()`の実行が走るごとに最初の行で`clearTimeout(this.timeoutId_)`を行う処理を追加（こうすることで前回のsetTimeout()の処理を中断します）