### PR TITLE
Feature/apply the pad key to the pads row sequence

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -158,6 +158,22 @@ export default class extends Controller {
   }
 
   updateLowerToUpper(event) {
+
+    // if the input letter *doesn't* include the following characters
+    // which correspond to each pad key!
+    if (![  't', 'y', 'u',
+            'g', 'h', 'j',
+            'b', 'n', 'm',
+      
+            'T', 'Y', 'U',
+            'G', 'H', 'J',
+            'B', 'N', 'M'
+      
+    // then replace it with blank.
+    ].includes(event.target.value)) {
+      event.target.value = ''
+    }
+
     event.target.value = event.target.value.toUpperCase()
   }
 }

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -156,4 +156,8 @@ export default class extends Controller {
     this.current_kickTarget.textContent = ""
     this.current_kickTarget.textContent = current_kick_name
   }
+
+  updateLowerToUpper(event) {
+    event.target.value = event.target.value.toUpperCase()
+  }
 }

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -157,7 +157,7 @@ export default class extends Controller {
     this.current_kickTarget.textContent = current_kick_name
   }
 
-  updateLowerToUpper(event) {
+  setThePad(event) {
 
     // if the input letter *doesn't* include the following characters
     // which correspond to each pad key!
@@ -168,9 +168,9 @@ export default class extends Controller {
             'T', 'Y', 'U',
             'G', 'H', 'J',
             'B', 'N', 'M'
-      
-    // then replace it with blank.
+
     ].includes(event.target.value)) {
+      // this means that users can input the letter that corresponds to any pad key only.
       event.target.value = ''
     }
 

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -95,7 +95,7 @@
               <% if row == 0 %>
                 <% if step % 4 == 0 %>
                   <div sample="chop" index="<%= step + 1 %>" data-active="false" data-step-sequencer-target="step">
-                    <input data-action="input->step-sequencer#updateLowerToUpper" class="ignore-keydown text-2xl font-bold aspect-square border border-black h-12 w-full rounded bg-gray-400 text-center" type="text" maxlength="1">
+                    <input data-action="input->step-sequencer#setThePad" class="ignore-keydown text-2xl font-bold aspect-square border border-black h-12 w-full rounded bg-gray-400 text-center" type="text" maxlength="1">
                   </div>
                 <% else %>
                   <div sample="chop" index="<%= step + 1 %>"data-active="false" class="aspect-square border border-black h-12 rounded" data-step-sequencer-target="step"></div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -98,7 +98,9 @@
                     <input data-action="input->step-sequencer#setThePad" class="ignore-keydown text-2xl font-bold aspect-square border border-black h-12 w-full rounded bg-gray-400 text-center" type="text" maxlength="1">
                   </div>
                 <% else %>
-                  <div sample="chop" index="<%= step + 1 %>"data-active="false" class="aspect-square border border-black h-12 rounded" data-step-sequencer-target="step"></div>
+                  <div sample="chop" index="<%= step + 1 %>" data-active="false" data-step-sequencer-target="step">
+                    <input data-action="input->step-sequencer#setThePad" class="ignore-keydown text-2xl font-bold aspect-square border border-black h-12 w-full rounded text-center" type="text" maxlength="1">
+                  </div>
                 <% end %>
               <% end %>
               <% if row == 1 %>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -95,7 +95,7 @@
               <% if row == 0 %>
                 <% if step % 4 == 0 %>
                   <div sample="chop" index="<%= step + 1 %>" data-active="false" data-step-sequencer-target="step">
-                    <input class="ignore-keydown text-2xl font-bold aspect-square border border-black h-12 w-full rounded bg-gray-400 text-center" type="text" maxlength="1">
+                    <input data-action="input->step-sequencer#updateLowerToUpper" class="ignore-keydown text-2xl font-bold aspect-square border border-black h-12 w-full rounded bg-gray-400 text-center" type="text" maxlength="1">
                   </div>
                 <% else %>
                   <div sample="chop" index="<%= step + 1 %>"data-active="false" class="aspect-square border border-black h-12 rounded" data-step-sequencer-target="step"></div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -94,11 +94,11 @@
             <% 16.times do |step| %>
               <% if row == 0 %>
                 <% if step % 4 == 0 %>
-                  <div sample="chop" index="<%= step + 1 %>" data-active="false" data-step-sequencer-target="step">
+                  <div index="<%= step + 1 %>">
                     <input data-action="input->step-sequencer#setThePad" class="ignore-keydown text-2xl font-bold aspect-square border border-black h-12 w-full rounded bg-gray-400 text-center" type="text" maxlength="1">
                   </div>
                 <% else %>
-                  <div sample="chop" index="<%= step + 1 %>" data-active="false" data-step-sequencer-target="step">
+                  <div index="<%= step + 1 %>">
                     <input data-action="input->step-sequencer#setThePad" class="ignore-keydown text-2xl font-bold aspect-square border border-black h-12 w-full rounded text-center" type="text" maxlength="1">
                   </div>
                 <% end %>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -94,7 +94,9 @@
             <% 16.times do |step| %>
               <% if row == 0 %>
                 <% if step % 4 == 0 %>
-                  <div sample="chop" index="<%= step + 1 %>"data-active="false" class="aspect-square border border-black h-12 rounded bg-gray-400" data-step-sequencer-target="step"></div>
+                  <div sample="chop" index="<%= step + 1 %>" data-active="false" data-step-sequencer-target="step">
+                    <input class="ignore-keydown text-2xl font-bold aspect-square border border-black h-12 w-full rounded bg-gray-400 text-center" type="text" maxlength="1">
+                  </div>
                 <% else %>
                   <div sample="chop" index="<%= step + 1 %>"data-active="false" class="aspect-square border border-black h-12 rounded" data-step-sequencer-target="step"></div>
                 <% end %>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -94,9 +94,9 @@
             <% 16.times do |step| %>
               <% if row == 0 %>
                 <% if step % 4 == 0 %>
-                  <div sample="chop" index="<%= step + 1 %>"data-active="false" class="aspect-square border border-black h-12 rounded bg-gray-400" data-step-sequencer-target="step"  data-action="click->step-sequencer#stepActiveControl"></div>
+                  <div sample="chop" index="<%= step + 1 %>"data-active="false" class="aspect-square border border-black h-12 rounded bg-gray-400" data-step-sequencer-target="step"></div>
                 <% else %>
-                  <div sample="chop" index="<%= step + 1 %>"data-active="false" class="aspect-square border border-black h-12 rounded" data-step-sequencer-target="step"  data-action="click->step-sequencer#stepActiveControl"></div>
+                  <div sample="chop" index="<%= step + 1 %>"data-active="false" class="aspect-square border border-black h-12 rounded" data-step-sequencer-target="step"></div>
                 <% end %>
               <% end %>
               <% if row == 1 %>

--- a/step-sequencer#updateLowerToUpper to make the input one letter from lowercase to uppercase
+++ b/step-sequencer#updateLowerToUpper to make the input one letter from lowercase to uppercase
@@ -1,0 +1,2 @@
+[feature/apply-the-pad-to-the-pads-row-sequence d22bf15] [add] data-action=input-
+ 1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
## 概要
パッドのキーの文字列のいずれか[t, y, u, g, h, j, b, n, m]をシーケンサーのPadsの列のステップにて入力できるようにしました。
[t, y, u, g, h, j, b, n, m,  T, Y, U, G, H, J, B, N, M]以外のものを入力することは出来ないようにしています。
また、小文字を入力した場合は非同期的に大文字に変換されるようにしました。

## 変更点
- 各ステップに対して`data-action="input->step-sequencer#setThePad"`を追加
- `setThePad(event)`を新規作成
- `setThePad(event)`で[t, y, u, g, h, j, b, n, m,  T, Y, U, G, H, J, B, N, M]以外のものを入力すると非同期的に空白に変換する（結果的にそれ以外の文字を入力することが出来ない）ような処理を追加
- `setThePad(event)`で小文字を大文字へ非同期的に更新する処理を追加