### PR TITLE
Feature/play the sequencer with the set pads

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -20,6 +20,8 @@ export default class extends Controller {
   }
 
   connect() {
+    this.youtubeController = document.querySelector('[data-controller~="youtube"]')?.youtube
+
   }
 
   currentBPM() {
@@ -73,6 +75,18 @@ export default class extends Controller {
     let beat = 0;
 
     await Tone.Transport.scheduleRepeat((time) => {
+      const padRow = rows[1]
+      const currentStep = padRow[beat]
+      const inputEl = currentStep.querySelector("input")
+
+      if (inputEl && inputEl.value) {
+        const key = inputEl.value.toLowerCase()
+        if (this.youtubeController) {
+          const Event = new KeyboardEvent("keydown", { key: key })
+          this.youtubeController.play(Event)
+        }
+      }
+
       rows.forEach((row, index) => {
         const step = row[beat];
         if (step.dataset.active === "true") {
@@ -95,6 +109,8 @@ export default class extends Controller {
     }, function() {
       Tone.Transport.start()
     }).toDestination()
+
+
 
     this.isPlaying = true
   }

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -102,7 +102,6 @@ export default class extends Controller {
     Tone.Transport.bpm.value = Number(this.current_bpmTarget.textContent)
 
     const players = new Tone.Players({
-      chop  : '/samples/snares/boom-bap-snare.wav',
       hihat : this.fetchSampleSoundPath(this.current_hihatTarget.textContent),
       snare : this.fetchSampleSoundPath(this.current_snareTarget.textContent),
       kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -126,7 +126,7 @@ export default class extends Controller {
 
   play(event) {
     clearTimeout(this.timeoutId_)
-    if(event.target.closest(".ignore-keydown")) return
+    if(event.target?.closest?.(".ignore-keydown")) return
     if(this.frameTarget.tagName == "DIV") return
 
     // start time


### PR DESCRIPTION
## 概要
16分のタイミングでpadsの行のステップを確認して、そこにパッドに対応したキーの文字列が入力されていれば、そのキーに対応してyoutube controllerのplay()を実行するように機能を追加しました。

## 変更点
- `ignore-keydown`がclassに含まれている場合に`play()`の実行を中断するが、`event.target.closest(".ignore-keydown")`だ`step_sequencer_controller.js`から`Event`を渡した場合にnullになってしまいエラーが出ることから、オプショナルチェーンをつけてnullの場合にエラーを出さずに中断するように修正しました。
- `this.youtubeController = document.querySelector('[data-controller~="youtube"]')?.youtube`でyoutubeコントローラーを取得するような処理を追加
- `Tone.Transport.scheduleRepeat`の中で、padsの行のステップを一つずつ取り出し、その中に入力された文字列がある場合にその文字列を小文字に変換してそれをkeydownの値とした上でyoutubeコントローラーの`play(Event)`を実行するような処理を追加

