### PR TITLE
Feature/adjust each drum volume but pads

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -199,4 +199,8 @@ export default class extends Controller {
 
     event.target.value = event.target.value.toUpperCase()
   }
+
+  hihatVolumeControl() {
+    this.hihatGain.gain.value = this.hihats_volumeTarget.value
+  }
 }

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -83,11 +83,11 @@ export default class extends Controller {
       hihat : this.fetchSampleSoundPath(this.current_hihatTarget.textContent),
       snare : this.fetchSampleSoundPath(this.current_snareTarget.textContent),
       kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)
-    }).connect({
-      hihat : this.hihatGain,
-      snare : this.snareGain,
-      kick  : this.kickGain
     }).toDestination()
+
+    players.player("hihat").connect(this.hihatGain)
+    players.player("snare").connect(this.snareGain)
+    players.player("kick").connect(this.kickGain)
     
     let beat = 0;
 

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -114,7 +114,7 @@ export default class extends Controller {
       kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)
     }, function() {
       Tone.Transport.start()
-    }).connnect({
+    }).connect({
       hihat : this.hihatGain,
       snare : this.snareGain,
       kick  : this.kickGain

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -29,6 +29,10 @@ export default class extends Controller {
     this.hihatGain = new Tone.Gain(1).toDestination()
     this.snareGain = new Tone.Gain(1).toDestination()
     this.kickGain = new Tone.Gain(1).toDestination()
+
+    this.hihatGain.gain.value = this.hihats_volumeTarget.value
+    this.snareGain.gain.value = this.snares_volumeTarget.value
+    this.kickGain.gain.value = this.kicks_volumeTarget.value
   }
 
   currentBPM() {

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -207,4 +207,8 @@ export default class extends Controller {
   snareVolumeControl() {
     this.snareGain.gain.value = this.snares_volumeTarget.value
   }
+
+  kickVolumeControl() {
+    this.kickGain.gain.value = this.kicks_volumeTarget.value
+  }
 }

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -13,7 +13,11 @@ export default class extends Controller {
                     "current_hihat",
                     "current_snare",
                     "current_kick",
-                    "indicator"
+                    "indicator",
+                    "pads_volume",
+                    "hihats_volume",
+                    "snares_volume",
+                    "kicks_volume",
   ]
 
   initialize() {

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -203,4 +203,8 @@ export default class extends Controller {
   hihatVolumeControl() {
     this.hihatGain.gain.value = this.hihats_volumeTarget.value
   }
+
+  snareVolumeControl() {
+    this.snareGain.gain.value = this.snares_volumeTarget.value
+  }
 }

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -114,6 +114,10 @@ export default class extends Controller {
       kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)
     }, function() {
       Tone.Transport.start()
+    }).connnect({
+      hihat : this.hihatGain,
+      snare : this.snareGain,
+      kick  : this.kickGain
     }).toDestination()
 
 

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -26,6 +26,9 @@ export default class extends Controller {
   connect() {
     this.youtubeController = document.querySelector('[data-controller~="youtube"]')?.youtube
 
+    this.hihatGain = new Tone.Gain(1).toDestination()
+    this.snareGain = new Tone.Gain(1).toDestination()
+    this.kickGain = new Tone.Gain(1).toDestination()
   }
 
   currentBPM() {

--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -79,6 +79,16 @@ export default class extends Controller {
       grid_array.slice(64,80)   // kick
     ];
 
+    const players = new Tone.Players({
+      hihat : this.fetchSampleSoundPath(this.current_hihatTarget.textContent),
+      snare : this.fetchSampleSoundPath(this.current_snareTarget.textContent),
+      kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)
+    }).connect({
+      hihat : this.hihatGain,
+      snare : this.snareGain,
+      kick  : this.kickGain
+    }).toDestination()
+    
     let beat = 0;
 
     await Tone.Transport.scheduleRepeat((time) => {
@@ -107,20 +117,7 @@ export default class extends Controller {
     }, "16n");
 
     Tone.Transport.bpm.value = Number(this.current_bpmTarget.textContent)
-
-    const players = new Tone.Players({
-      hihat : this.fetchSampleSoundPath(this.current_hihatTarget.textContent),
-      snare : this.fetchSampleSoundPath(this.current_snareTarget.textContent),
-      kick  : this.fetchSampleSoundPath(this.current_kickTarget.textContent)
-    }, function() {
-      Tone.Transport.start()
-    }).connect({
-      hihat : this.hihatGain,
-      snare : this.snareGain,
-      kick  : this.kickGain
-    }).toDestination()
-
-
+    Tone.Transport.start()
 
     this.isPlaying = true
   }

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -16,16 +16,16 @@
         <div class="mt-8">
           <div class="grid grid-cols-1 gap-8">
             <div>
-              <input type="range" data-step-sequencer-target="pads_volume" class="mr-4">
+              <input type="range" min="0" max="1" step="0.01" data-step-sequencer-target="pads_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" data-step-sequencer-target="hihats_volume" class="mr-4">
+              <input type="range" min="0" max="1" step="0.01" data-step-sequencer-target="hihats_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" data-step-sequencer-target="snares_volume" class="mr-4">
+              <input type="range" min="0" max="1" step="0.01" data-step-sequencer-target="snares_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" data-step-sequencer-target="kicks_volume" class="mr-4">
+              <input type="range" min="0" max="1" step="0.01" data-step-sequencer-target="kicks_volume" class="mr-4">
             </div>
           </div>
         </div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -19,13 +19,13 @@
               <input type="range" min="0" max="1" step="0.01" data-step-sequencer-target="pads_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" min="0" max="1" step="0.01" data-step-sequencer-target="hihats_volume" class="mr-4">
+              <input type="range" min="0" max="1" step="0.01" data-action="step-sequencer#hihatVolumeControl" data-step-sequencer-target="hihats_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" min="0" max="1" step="0.01" data-step-sequencer-target="snares_volume" class="mr-4">
+              <input type="range" min="0" max="1" step="0.01" data-action="step-sequencer#snareVolumeControl" data-step-sequencer-target="snares_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" min="0" max="1" step="0.01" data-step-sequencer-target="kicks_volume" class="mr-4">
+              <input type="range" min="0" max="1" step="0.01" data-action="step-sequencer#kickVolumeControl" data-step-sequencer-target="kicks_volume" class="mr-4">
             </div>
           </div>
         </div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -16,16 +16,16 @@
         <div class="mt-8">
           <div class="grid grid-cols-1 gap-8">
             <div>
-              <input type="range" class="mr-4">
+              <input type="range" data-step-sequencer-target="pads_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" class="mr-4">
+              <input type="range" data-step-sequencer-target="hihats_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" class="mr-4">
+              <input type="range" data-step-sequencer-target="snares_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" class="mr-4">
+              <input type="range" data-step-sequencer-target="kicks_volume" class="mr-4">
             </div>
           </div>
         </div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -12,7 +12,23 @@
       </div>
     </div>
     <div class="mb-4">
-      <div class="flex items-center justify-center">
+      <div class="flex justify-center items-center">
+        <div class="mt-8">
+          <div class="grid grid-cols-1 gap-8">
+            <div>
+              <input type="range" class="mr-4">
+            </div>
+            <div>
+              <input type="range" class="mr-4">
+            </div>
+            <div>
+              <input type="range" class="mr-4">
+            </div>
+            <div>
+              <input type="range" class="mr-4">
+            </div>
+          </div>
+        </div>
         <div class="mt-8">
           <div class="grid grid-cols-1 gap-2">
             <div class="flex items-center justify-center">

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -16,16 +16,16 @@
         <div class="mt-8">
           <div class="grid grid-cols-1 gap-8">
             <div>
-              <input type="range" min="-1" max="1" step="0.01" data-step-sequencer-target="pads_volume" class="mr-4">
+              <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-step-sequencer-target="pads_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" min="-1" max="1" step="0.01" data-action="step-sequencer#hihatVolumeControl" data-step-sequencer-target="hihats_volume" class="mr-4">
+              <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="step-sequencer#hihatVolumeControl" data-step-sequencer-target="hihats_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" min="-1" max="1" step="0.01" data-action="step-sequencer#snareVolumeControl" data-step-sequencer-target="snares_volume" class="mr-4">
+              <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="step-sequencer#snareVolumeControl" data-step-sequencer-target="snares_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" min="-1" max="1" step="0.01" data-action="step-sequencer#kickVolumeControl" data-step-sequencer-target="kicks_volume" class="mr-4">
+              <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="step-sequencer#kickVolumeControl" data-step-sequencer-target="kicks_volume" class="mr-4">
             </div>
           </div>
         </div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -16,16 +16,16 @@
         <div class="mt-8">
           <div class="grid grid-cols-1 gap-8">
             <div>
-              <input type="range" min="0" max="1" step="0.01" data-step-sequencer-target="pads_volume" class="mr-4">
+              <input type="range" min="-1" max="1" step="0.01" data-step-sequencer-target="pads_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" min="0" max="1" step="0.01" data-action="step-sequencer#hihatVolumeControl" data-step-sequencer-target="hihats_volume" class="mr-4">
+              <input type="range" min="-1" max="1" step="0.01" data-action="step-sequencer#hihatVolumeControl" data-step-sequencer-target="hihats_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" min="0" max="1" step="0.01" data-action="step-sequencer#snareVolumeControl" data-step-sequencer-target="snares_volume" class="mr-4">
+              <input type="range" min="-1" max="1" step="0.01" data-action="step-sequencer#snareVolumeControl" data-step-sequencer-target="snares_volume" class="mr-4">
             </div>
             <div>
-              <input type="range" min="0" max="1" step="0.01" data-action="step-sequencer#kickVolumeControl" data-step-sequencer-target="kicks_volume" class="mr-4">
+              <input type="range" min="-1" max="1" step="0.01" data-action="step-sequencer#kickVolumeControl" data-step-sequencer-target="kicks_volume" class="mr-4">
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概要
hihat, snare, kickの各行のステップで鳴らされる音量を調整できるようにしました。

## 変更点
- 音量調整をするための`input range`のそれぞれのターゲットを追加
- 各Gainノードの新規作成
- `players`の中の`player`をそれぞれ対応するgainノードに接続（こうすることで、`player -> output`だったのが`player -> gain -> output`という順序となり、音が出力される前のgainの段階で音量調整をしてから出力できるようにしています）
- 各range inputにdata-actionを追加し、inputで入力値が変化する度にそのinputに対応したVolumeControl()が実行されるようにしました（`hihat`の行の音量を調整すると`hihatVolumeControl()`によって音量が調整される）
- 各`input type="range"`に対して、最小値と最大値と初期値、どの段階で変化するかの値を設定