### PR TITLE
Feature/adjust volume of pads row

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -14,7 +14,6 @@ export default class extends Controller {
                     "current_snare",
                     "current_kick",
                     "indicator",
-                    "pads_volume",
                     "hihats_volume",
                     "snares_volume",
                     "kicks_volume",

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -101,6 +101,7 @@ export default class extends Controller {
         },
         events: {
           onReady: (event) => {
+            event.target.setVolume(20)
             event.target.playVideo()
           }
         }
@@ -117,6 +118,7 @@ export default class extends Controller {
         },
         events: {
           onReady: (event) => {
+            event.target.setVolume(20)
             event.target.playVideo()
           }
         }

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -43,7 +43,8 @@ export default class extends Controller {
                     "m_start_time",
                     "m_start_time_decimal",
                     "m_end_time",
-                    "m_end_time_decimal"
+                    "m_end_time_decimal",
+                    "pads_volume",
   ]
 
   initialize() {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -156,6 +156,10 @@ export default class extends Controller {
     }, playingTimeTotalSecond * 1000)
   }
 
+  padVolumeControl () {
+    this.getPlayer.setVolume(this.pads_volumeTarget.value)
+  }
+
   targetTime(event) {
     if(event.key == "t") return {
       start:          this.t_start_timeTarget, 

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -16,7 +16,7 @@
         <div class="mt-8">
           <div class="grid grid-cols-1 gap-8">
             <div>
-              <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="youtube#padVolumeControl" data-youtube-target="pads_volume" class="mr-4">
+              <input type="range" value="20" min="0" max="100" step="1" data-action="youtube#padVolumeControl" data-youtube-target="pads_volume" class="mr-4">
             </div>
             <div>
               <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="step-sequencer#hihatVolumeControl" data-step-sequencer-target="hihats_volume" class="mr-4">

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -16,7 +16,7 @@
         <div class="mt-8">
           <div class="grid grid-cols-1 gap-8">
             <div>
-              <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="youtube#padVolumeControl" data-step-sequencer-target="pads_volume" class="mr-4">
+              <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="youtube#padVolumeControl" data-youtube-target="pads_volume" class="mr-4">
             </div>
             <div>
               <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="step-sequencer#hihatVolumeControl" data-step-sequencer-target="hihats_volume" class="mr-4">

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -16,7 +16,7 @@
         <div class="mt-8">
           <div class="grid grid-cols-1 gap-8">
             <div>
-              <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-step-sequencer-target="pads_volume" class="mr-4">
+              <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="youtube#padVolumeControl" data-step-sequencer-target="pads_volume" class="mr-4">
             </div>
             <div>
               <input type="range" value="-0.8" min="-1" max="1" step="0.01" data-action="step-sequencer#hihatVolumeControl" data-step-sequencer-target="hihats_volume" class="mr-4">


### PR DESCRIPTION
## 概要
シーケンサーのパッドの行の先頭のレンジを変更すると、Youtubeの動画の音量が調整できるようにしました。（これはシーケンサーを`Play`した時のパッドが鳴らされる時の音量と共通している）

## 変更点
- `"pads_volume"`ターゲットを`step_sequencer_controller.js`から`youtube_controller.js`で使えるように移動
- 動画が埋め込まれた時にデフォルトで20%の音量になるようにする処理を追加
- padsの行の`input type="range"`に`data-action="youtube#padVolumeControl"`を追加
- `padVolumeControl()`でinputの値が変化するごとにyoutubeの動画の音量を変更する処理を追加
- `input type="range"`のmin, max, value, stepの値を変更（youtube iframe apiは最小値0, 最大値100の間で音量を決定しているらしいのでそれに合わせました）