### PR TITLE
Feature/reset the sequencer

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -214,4 +214,24 @@ export default class extends Controller {
   kickVolumeControl() {
     this.kickGain.gain.value = this.kicks_volumeTarget.value
   }
+
+  resetAllStepsActive () {
+    const stepsCollection = this.gridTarget.children
+    const stepsArray = Array.prototype.slice.call(stepsCollection)
+    const drumsStepsArray = stepsArray.slice(32,80)
+
+    drumsStepsArray.forEach((step) => {
+      const isActive = step.dataset.active === "true"
+      if (isActive == true) {
+        if (step.getAttribute('index') % 4 == 1) {
+          step.classList.remove('bg-green-300')
+          step.classList.add('bg-gray-400')
+        } else {
+          step.classList.remove('bg-green-300')
+        }
+      }
+      
+      step.setAttribute('data-active', 'false')
+    })
+  }
 }

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -10,7 +10,7 @@
         <button class="bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#playSequencer">Play</button>
         <button class="bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#stopSequencer">Stop</button>
         <!-- Modal toggle -->
-        <div class="mb-1 w-[16px]">
+        <div class="mb-1 w-[16px] px-2">
             <div id="resetStepsActiveButton" data-modal-target="deleteStepsModal" data-modal-toggle="deleteStepsModal" type="button">
               <%= fa_icon "trash 2x" %>
             </div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -11,13 +11,13 @@
         <button class="bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#stopSequencer">Stop</button>
         <!-- Modal toggle -->
         <div class="mb-1 w-[16px]">
-            <div id="deleteButton" data-modal-target="deleteModal" data-modal-toggle="deleteModal" type="button">
+            <div id="resetStepsActiveButton" data-modal-target="deleteStepsModal" data-modal-toggle="deleteStepsModal" type="button">
               <%= fa_icon "trash 2x" %>
             </div>
         </div>
 
         <!-- Main modal -->
-        <div data-youtube-target="reset_confirmation" id="deleteModal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-modal md:h-full">
+        <div data-youtube-target="reset_confirmation" id="deleteStepsModal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-modal md:h-full">
             <div class="relative p-4 w-full max-w-md h-full md:h-auto">
                 <!-- Modal content -->
                 <div class="relative p-4 text-center bg-white rounded-lg shadow dark:bg-gray-800 sm:p-5">
@@ -28,10 +28,10 @@
                     <svg class="text-gray-400 dark:text-gray-500 w-11 h-11 mb-3.5 mx-auto" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path></svg>
                     <p class="mb-4 text-gray-700 dark:text-gray-300">Are you sure you want to clear all active steps?</p>
                     <div class="flex justify-center items-center space-x-4">
-                        <button data-modal-toggle="deleteModal" type="button" class="py-2 px-3 text-sm font-medium text-gray-700 bg-white rounded-lg border border-gray-200 hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-primary-300 hover:text-gray-900 focus:z-10 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-500 dark:hover:text-white dark:hover:bg-gray-600 dark:focus:ring-gray-600">
+                        <button data-modal-toggle="deleteStepsModal" type="button" class="py-2 px-3 text-sm font-medium text-gray-700 bg-white rounded-lg border border-gray-200 hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-primary-300 hover:text-gray-900 focus:z-10 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-500 dark:hover:text-white dark:hover:bg-gray-600 dark:focus:ring-gray-600">
                             No, cancel
                         </button>
-                        <button data-action="click->step-sequencer#resetAllStepsActive" data-modal-toggle="deleteModal" type="submit" class="py-2 px-3 text-sm font-medium text-center text-white bg-red-600 rounded-lg hover:bg-red-700 focus:ring-4 focus:outline-none focus:ring-red-300 dark:bg-red-500 dark:hover:bg-red-600 dark:focus:ring-red-900">
+                        <button data-action="click->step-sequencer#resetAllStepsActive" data-modal-toggle="deleteStepsModal" type="submit" class="py-2 px-3 text-sm font-medium text-center text-white bg-red-600 rounded-lg hover:bg-red-700 focus:ring-4 focus:outline-none focus:ring-red-300 dark:bg-red-500 dark:hover:bg-red-600 dark:focus:ring-red-900">
                             Yes, I'm sure
                         </button>
                     </div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -9,6 +9,35 @@
         <input type="range" id="bpm" min="60" max="240" value="90" data-action="input->step-sequencer#currentBPM" data-step-sequencer-target="bpm">
         <button class="bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#playSequencer">Play</button>
         <button class="bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#stopSequencer">Stop</button>
+        <!-- Modal toggle -->
+        <div class="mb-1 w-[16px]">
+            <div id="deleteButton" data-modal-target="deleteModal" data-modal-toggle="deleteModal" type="button">
+              <%= fa_icon "trash 2x" %>
+            </div>
+        </div>
+
+        <!-- Main modal -->
+        <div data-youtube-target="reset_confirmation" id="deleteModal" tabindex="-1" aria-hidden="true" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-modal md:h-full">
+            <div class="relative p-4 w-full max-w-md h-full md:h-auto">
+                <!-- Modal content -->
+                <div class="relative p-4 text-center bg-white rounded-lg shadow dark:bg-gray-800 sm:p-5">
+                    <button type="button" class="text-gray-400 absolute top-2.5 right-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white" data-modal-toggle="deleteModal">
+                        <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+                        <span class="sr-only">Close modal</span>
+                    </button>
+                    <svg class="text-gray-400 dark:text-gray-500 w-11 h-11 mb-3.5 mx-auto" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path></svg>
+                    <p class="mb-4 text-gray-700 dark:text-gray-300">Are you sure you want to clear all active steps?</p>
+                    <div class="flex justify-center items-center space-x-4">
+                        <button data-modal-toggle="deleteModal" type="button" class="py-2 px-3 text-sm font-medium text-gray-700 bg-white rounded-lg border border-gray-200 hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-primary-300 hover:text-gray-900 focus:z-10 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-500 dark:hover:text-white dark:hover:bg-gray-600 dark:focus:ring-gray-600">
+                            No, cancel
+                        </button>
+                        <button data-action="click->step-sequencer#resetAllStepsActive" data-modal-toggle="deleteModal" type="submit" class="py-2 px-3 text-sm font-medium text-center text-white bg-red-600 rounded-lg hover:bg-red-700 focus:ring-4 focus:outline-none focus:ring-red-300 dark:bg-red-500 dark:hover:bg-red-600 dark:focus:ring-red-900">
+                            Yes, I'm sure
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
       </div>
     </div>
     <div class="mb-4">


### PR DESCRIPTION
## 概要
シークエンサー上部に配置されたゴミ箱ボタンをクリックして確認メッセージが表示されて最後に"Yes"ボタンをクリックすると、シークエンサーのアクティブ状態のステップが全てリセットされるような機能を追加しました。
具体的にはアクティブ状態になると背景色が薄緑色になるのを元の色に戻して、`data-active`の属性値を`false`に変更します。

## 変更点
- リセット確認メッセージを表示するためのゴミ箱アイコンの表示
- ゴミ箱アイコンをクリックした際のリセット確認メッセージの表示
- リセット確認メッセージで"Yes"ボタンをクリックすると`step-sequencer#resetAllStepsActive`が実行されるように定義
- `resetAllStepsActive ()`内で背景色をデフォルト状態の戻す処理と、`data-active`の属性値を`false`にする処理を追加