### PR TITLE
Feature/set the timings in default

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -50,6 +50,21 @@ export default class extends Controller {
 
   initialize() {
     this.element['youtube'] = this
+
+    this.y_start_timeTarget.value = "00:41"
+    this.y_end_timeTarget.value = "00:42"
+    this.y_end_time_decimalTarget.value = "1"
+
+    this.j_start_timeTarget.value = "01:25"
+    this.j_start_time_decimalTarget.value = "2"
+    this.j_end_timeTarget.value = "02:00"
+
+    this.m_start_timeTarget.value = "02:56"
+    this.m_start_time_decimalTarget.value = "1"
+    this.m_end_timeTarget.value = "12:00"
+
+    this.t_start_timeTarget.value = "01:08"
+    this.t_end_timeTarget.value = "12:00"
   }
 
   connect() {
@@ -158,7 +173,6 @@ export default class extends Controller {
   }
 
   play(event) {
-    console.log(this.getPlayer)
     clearTimeout(this.timeoutId_)
     if(event.target?.closest?.(".ignore-keydown")) return
     if(this.frameTarget.tagName == "DIV") return


### PR DESCRIPTION
## 概要
トップページにアクセスした時点でデフォルトでパッドに既定の時間が入力されているように変更しました。　

## 変更点
- `initialize()`にてパッドの`input type="time"` or `input type="text"`に対して既定の時間を入力しておく処理を追加