### PR TITLE
Feature/set the playback speed in default

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -96,6 +96,7 @@ export default class extends Controller {
       events: {
         onReady: (event) => {
           event.target.setVolume(20)
+          event.target.setPlaybackRate(1.2)
           event.target.playVideo()
         }
       }

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -64,6 +64,7 @@ export default class extends Controller {
     this.m_end_timeTarget.value = "12:00"
 
     this.t_start_timeTarget.value = "01:08"
+    this.t_start_time_decimalTarget.value = "3"
     this.t_end_timeTarget.value = "12:00"
   }
 

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -4,9 +4,9 @@
       <div class="flex justify-center items-center gap-3">
         <div class="flex items-center">
           <label for="bpm">BPM:</label>
-          <div class="text-lg mr-2 w-12" data-step-sequencer-target="current_bpm">90</div>
+          <div class="text-lg mr-2 w-12" data-step-sequencer-target="current_bpm">94</div>
         </div>
-        <input type="range" id="bpm" min="60" max="240" value="90" data-action="input->step-sequencer#currentBPM" data-step-sequencer-target="bpm">
+        <input type="range" id="bpm" min="60" max="240" value="94" data-action="input->step-sequencer#currentBPM" data-step-sequencer-target="bpm">
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#playSequencer">Play</button>
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#stopSequencer">Stop</button>
         <!-- Modal toggle -->


### PR DESCRIPTION
## 概要
トップページアクセス時点で埋め込まれている動画の再生速度をデフォルトで`1.2`に設定しました。
また、BPMを`94`にしました。

## 変更点
- デフォルトのbpmの値を`94`に変更
- iframe埋め込み時に`event.target.setPlaybackRate(1.2)`で再生速度のレートを1.2に変更