### PR TITLE
Feature/deny mobile access

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,9 @@
   </head>
 
   <body class="flex flex-col min-h-screen">
-    <%= render "shared/header" %>
+    <div class="w-full">
+      <%= render "shared/header" %>
+    </div>
     <main class="flex-grow flex items-center justify-center">
       <%= yield %>
     </main>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="">
+<header>
     <nav class="bg-gray-900 shadow-lg border-gray-200 px-4 lg:px-6 py-2.5 dark:bg-gray-800">
         <div class="flex flex-wrap justify-between items-center mx-auto max-w-screen-xl">
           <a href="#" class="-m-1.5 p-1.5">
@@ -119,6 +119,3 @@
         </div>
     </nav>
 </header>
-
-    <div class="flex lg:flex-1">
-    </div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="hidden md:block">
   <div data-controller="youtube" data-action="
     keydown.t@document->youtube#play 
     keydown.y@document->youtube#play
@@ -31,4 +31,8 @@
       </div>
     </div>
   </div>
+</div>
+<div class="md:hidden text-center font-medium">
+  <p>For the best experience, please access this site from a desktop or laptop computer,</p>
+  <p>as it may be too heavy for mobile devices.</p>
 </div>


### PR DESCRIPTION
## 概要
Youtube iFrame APIとTone.jsを重ねたものの場合、モバイルだとめちゃくちゃ重くてこのWebアプリをまともに使えないことが判明したので、モバイルからの動線は断念。（単に再生するだけなら全く問題はないが、このWebアプリのように短時間のうちに動画のあらゆる地点に移動するような処理は読み込みが追いつかない。）

## 変更点
- モバイルサイズからのアクセスの場合、PCからのアクセスを求める文言を表示するように変更。