### PR TITLE
Feature/set current video times

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -298,6 +298,11 @@ export default class extends Controller {
         var startTimeInput = this.n_start_timeTarget
         var startTimeDecimalPart = this.n_start_time_decimalTarget
       }
+    if (event.target.id == 'm_set_current_time_button') 
+      {
+        var startTimeInput = this.m_start_timeTarget
+        var startTimeDecimalPart = this.m_start_time_decimalTarget
+      }
 
     startTimeInput.value = inputCurrentTimeIntPart
     startTimeDecimalPart.value = currentTimeDecimalPart

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -251,8 +251,13 @@ export default class extends Controller {
 
     const inputCurrentTimeIntPart = currentTimeMinStr + ':' + currentTimeSecStr
 
-    const startTimeInput = event.target.closest("#dropdownHoverT")?.querySelector('[data-youtube-target="t_start_time"]');
-    const startTimeDecimalPart = event.target.closest("#dropdownHoverT")?.querySelector('[data-youtube-target="t_start_time_decimal"]');
+    // const startTimeInput = event.target.closest("#dropdownHoverT")
+    // const startTimeDecimalPart = event.target.closest("#dropdownHoverT")
+    if (event.target.id == 't_set_current_time_button') 
+      {
+        var startTimeInput = this.t_start_timeTarget
+        var startTimeDecimalPart = this.t_start_time_decimalTarget
+      }
 
     startTimeInput.value = inputCurrentTimeIntPart
     startTimeDecimalPart.value = currentTimeDecimalPart

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -226,7 +226,7 @@ export default class extends Controller {
     this.getPlayer.setVolume(this.pads_volumeTarget.value)
   }
 
-  setTheCurrentTime () {
+  setTheCurrentTime (event) {
     const currentTime = Math.floor(this.getPlayer.getCurrentTime() * 10) / 10
     const currentTimeIntPart = Math.trunc(currentTime)
     const currentTimeDecimalPart = Math.round((currentTime - currentTimeIntPart) * 10)
@@ -249,9 +249,13 @@ export default class extends Controller {
       var currentTimeSecStr = String(currentTimeSecPart) // xx
     }
 
-    const inputCurrentTime = currentTimeMinStr + ':' + currentTimeSecStr
+    const inputCurrentTimeIntPart = currentTimeMinStr + ':' + currentTimeSecStr
 
-    
+    const startTimeInput = event.target.closest("#dropdownHoverT")?.querySelector('[data-youtube-target="t_start_time"]');
+    const startTimeDecimalPart = event.target.closest("#dropdownHoverT")?.querySelector('[data-youtube-target="t_start_time_decimal"]');
+
+    startTimeInput.value = inputCurrentTimeIntPart
+    startTimeDecimalPart.value = currentTimeDecimalPart
   }
 
   resetAllInputTimings () {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -258,6 +258,46 @@ export default class extends Controller {
         var startTimeInput = this.t_start_timeTarget
         var startTimeDecimalPart = this.t_start_time_decimalTarget
       }
+    if (event.target.id == 'y_set_current_time_button') 
+      {
+        var startTimeInput = this.y_start_timeTarget
+        var startTimeDecimalPart = this.y_start_time_decimalTarget
+      }
+    if (event.target.id == 'u_set_current_time_button') 
+      {
+        var startTimeInput = this.u_start_timeTarget
+        var startTimeDecimalPart = this.u_start_time_decimalTarget
+      }
+    if (event.target.id == 'g_set_current_time_button') 
+      {
+        var startTimeInput = this.g_start_timeTarget
+        var startTimeDecimalPart = this.g_start_time_decimalTarget
+      }
+    if (event.target.id == 'h_set_current_time_button') 
+      {
+        var startTimeInput = this.h_start_timeTarget
+        var startTimeDecimalPart = this.h_start_time_decimalTarget
+      }
+    if (event.target.id == 'j_set_current_time_button') 
+      {
+        var startTimeInput = this.j_start_timeTarget
+        var startTimeDecimalPart = this.j_start_time_decimalTarget
+      }
+    if (event.target.id == 'b_set_current_time_button') 
+      {
+        var startTimeInput = this.b_start_timeTarget
+        var startTimeDecimalPart = this.b_start_time_decimalTarget
+      }
+    if (event.target.id == 'n_set_current_time_button') 
+      {
+        var startTimeInput = this.n_start_timeTarget
+        var startTimeDecimalPart = this.n_start_time_decimalTarget
+      }
+    if (event.target.id == 'n_set_current_time_button') 
+      {
+        var startTimeInput = this.n_start_timeTarget
+        var startTimeDecimalPart = this.n_start_time_decimalTarget
+      }
 
     startTimeInput.value = inputCurrentTimeIntPart
     startTimeDecimalPart.value = currentTimeDecimalPart

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -226,6 +226,34 @@ export default class extends Controller {
     this.getPlayer.setVolume(this.pads_volumeTarget.value)
   }
 
+  setTheCurrentTime () {
+    const currentTime = Math.floor(this.getPlayer.getCurrentTime() * 10) / 10
+    const currentTimeIntPart = Math.trunc(currentTime)
+    const currentTimeDecimalPart = Math.round((currentTime - currentTimeIntPart) * 10)
+
+    // this is the left min part of 00:00
+    const currentTimeMinPart = Math.trunc(currentTimeIntPart / 60)
+    
+    if (currentTimeMinPart.toString().length == 1) {
+      var currentTimeMinStr = '0' + currentTimeMinPart // 0x
+    } else {
+      var currentTimeMinStr = String(currentTimeMinPart) // xx
+    }
+
+    // this is the right sec part of 00:00
+    const currentTimeSecPart = currentTimeIntPart - (currentTimeMinPart * 60)
+
+    if (currentTimeSecPart.toString().length == 1) {
+      var currentTimeSecStr = '0' + currentTimeSecPart // 0x
+    } else {
+      var currentTimeSecStr = String(currentTimeSecPart) // xx
+    }
+
+    const inputCurrentTime = currentTimeMinStr + ':' + currentTimeSecStr
+
+    
+  }
+
   resetAllInputTimings () {
     this.t_start_timeTarget.value = "00:00"
     this.t_start_time_decimalTarget.value = "0"

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -66,7 +66,7 @@
               </div>
               <div class="flex items-center justify-center">
                 <div class="mt-7 p-2">
-                  <button type="button" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
+                  <button type="button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
                 </div>
               </div>
             </div>

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -98,6 +98,11 @@
                   <input data-youtube-target="y_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
+              <div class="flex items-center justify-center">
+                <div class="mt-7 p-2">
+                  <button type="button" id="y_set_current_time_button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -125,6 +130,11 @@
                     <div class="font-bold text-3xl">.</div>
                   </div>
                   <input data-youtube-target="u_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                </div>
+              </div>
+              <div class="flex items-center justify-center">
+                <div class="mt-7 p-2">
+                  <button type="button" id="u_set_current_time_button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
                 </div>
               </div>
             </div>
@@ -156,6 +166,11 @@
                   <input data-youtube-target="g_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
+              <div class="flex items-center justify-center">
+                <div class="mt-7 p-2">
+                  <button type="button" id="g_set_current_time_button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -183,6 +198,11 @@
                     <div class="font-bold text-3xl">.</div>
                   </div>
                   <input data-youtube-target="h_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                </div>
+              </div>
+              <div class="flex items-center justify-center">
+                <div class="mt-7 p-2">
+                  <button type="button" id="h_set_current_time_button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
                 </div>
               </div>
             </div>
@@ -214,6 +234,11 @@
                   <input data-youtube-target="j_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
+              <div class="flex items-center justify-center">
+                <div class="mt-7 p-2">
+                  <button type="button" id="j_set_current_time_button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -241,6 +266,11 @@
                     <div class="font-bold text-3xl">.</div>
                   </div>
                   <input data-youtube-target="b_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                </div>
+              </div>
+              <div class="flex items-center justify-center">
+                <div class="mt-7 p-2">
+                  <button type="button" id="b_set_current_time_button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
                 </div>
               </div>
             </div>
@@ -272,6 +302,11 @@
                   <input data-youtube-target="n_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
+              <div class="flex items-center justify-center">
+                <div class="mt-7 p-2">
+                  <button type="button" id="n_set_current_time_button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -299,6 +334,11 @@
                     <div class="font-bold text-3xl">.</div>
                   </div>
                   <input data-youtube-target="m_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                </div>
+              </div>
+              <div class="flex items-center justify-center">
+                <div class="mt-7 p-2">
+                  <button type="button" id="m_set_current_time_button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
                 </div>
               </div>
             </div>

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -66,7 +66,7 @@
               </div>
               <div class="flex items-center justify-center">
                 <div class="mt-7 p-2">
-                  <button type="button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
+                  <button type="button" id="t_set_current_time_button" data-action="click->youtube#setTheCurrentTime" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
                 </div>
               </div>
             </div>

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -64,6 +64,11 @@
                   <input data-youtube-target="t_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
+              <div class="flex items-center justify-center">
+                <div class="mt-7 p-2">
+                  <button type="button" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800">Set the current time</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概要
パッドの中の「set the current time」ボタンを押すと、現在の再生地点の時間がパッドメニュー内の再生開始時間の`input`に非同期的に反映されるようにしました。

## 変更点
- `setTheCurrentTime (event)`の追加