### PR TITLE
Feature/hour time input

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -291,56 +291,52 @@ export default class extends Controller {
 
     // const startTimeInput = event.target.closest("#dropdownHoverT")
     // const startTimeDecimalPart = event.target.closest("#dropdownHoverT")
-    if (event.target.id == 't_set_current_time_button') 
-      {
+    switch (event.target.id) {
+      case 't_set_current_time_button':
         var startTimeInput = this.t_start_timeTarget
         var startTimeDecimalPart = this.t_start_time_decimalTarget
-      }
-    if (event.target.id == 'y_set_current_time_button') 
-      {
+        break;
+      
+      case 'y_set_current_time_button':
         var startTimeInput = this.y_start_timeTarget
         var startTimeDecimalPart = this.y_start_time_decimalTarget
-      }
-    if (event.target.id == 'u_set_current_time_button') 
-      {
+        break;
+      
+      case 'u_set_current_time_button':
         var startTimeInput = this.u_start_timeTarget
         var startTimeDecimalPart = this.u_start_time_decimalTarget
-      }
-    if (event.target.id == 'g_set_current_time_button') 
-      {
+        break;
+      
+      case 'g_set_current_time_button':
         var startTimeInput = this.g_start_timeTarget
         var startTimeDecimalPart = this.g_start_time_decimalTarget
-      }
-    if (event.target.id == 'h_set_current_time_button') 
-      {
+        break;
+      
+      case 'h_set_current_time_button':
         var startTimeInput = this.h_start_timeTarget
         var startTimeDecimalPart = this.h_start_time_decimalTarget
-      }
-    if (event.target.id == 'j_set_current_time_button') 
-      {
+        break;
+
+      case 'j_set_current_time_button':
         var startTimeInput = this.j_start_timeTarget
         var startTimeDecimalPart = this.j_start_time_decimalTarget
-      }
-    if (event.target.id == 'b_set_current_time_button') 
-      {
+        break;
+
+      case 'b_set_current_time_button':
         var startTimeInput = this.b_start_timeTarget
         var startTimeDecimalPart = this.b_start_time_decimalTarget
-      }
-    if (event.target.id == 'n_set_current_time_button') 
-      {
+        break;
+
+      case 'n_set_current_time_button':
         var startTimeInput = this.n_start_timeTarget
         var startTimeDecimalPart = this.n_start_time_decimalTarget
-      }
-    if (event.target.id == 'n_set_current_time_button') 
-      {
-        var startTimeInput = this.n_start_timeTarget
-        var startTimeDecimalPart = this.n_start_time_decimalTarget
-      }
-    if (event.target.id == 'm_set_current_time_button') 
-      {
+        break;
+
+      case 'm_set_current_time_button':
         var startTimeInput = this.m_start_timeTarget
         var startTimeDecimalPart = this.m_start_time_decimalTarget
-      }
+        break;
+    }
 
     startTimeInput.value = inputCurrentTimeIntPart
     startTimeDecimalPart.value = currentTimeDecimalPart

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -72,9 +72,9 @@ export default class extends Controller {
     this.m_start_time_decimalTarget.value = "1"
     this.m_end_timeTarget.value = "12:00"
 
-    this.t_start_timeTarget.value = "01:08"
+    this.t_start_timeTarget.value = "00:01:08"
     this.t_start_time_decimalTarget.value = "3"
-    this.t_end_timeTarget.value = "12:00"
+    this.t_end_timeTarget.value = "00:59:10"
   }
 
   connect() {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -72,6 +72,10 @@ export default class extends Controller {
     this.u_end_timeTarget.value = "00:59:10"
     this.u_end_time_decimalTarget.value = "1"
 
+    this.g_start_timeTarget.value = "00:02:10"
+    this.g_end_timeTarget.value = "00:59:10"
+    this.g_end_time_decimalTarget.value = "1"
+
     this.j_start_timeTarget.value = "01:25"
     this.j_start_time_decimalTarget.value = "2"
     this.j_end_timeTarget.value = "02:00"

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -61,8 +61,8 @@ export default class extends Controller {
     this.element['youtube'] = this
     
     this.t_start_timeTarget.value = "00:01:08"
-    this.t_end_timeTarget.value = "00:59:10"
     this.t_start_time_decimalTarget.value = "3"
+    this.t_end_timeTarget.value = "00:59:10"
 
     this.y_start_timeTarget.value = "00:00:41"
     this.y_end_timeTarget.value = "00:00:42"
@@ -70,15 +70,12 @@ export default class extends Controller {
 
     this.u_start_timeTarget.value = "00:01:41"
     this.u_end_timeTarget.value = "00:59:10"
-    this.u_end_time_decimalTarget.value = "1"
 
     this.g_start_timeTarget.value = "00:02:10"
     this.g_end_timeTarget.value = "00:59:10"
-    this.g_end_time_decimalTarget.value = "1"
 
     this.h_start_timeTarget.value = "00:02:32"
     this.h_end_timeTarget.value = "00:59:10"
-    this.h_end_time_decimalTarget.value = "1"
 
     this.j_start_timeTarget.value = "00:01:25"
     this.j_start_time_decimalTarget.value = "2"

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -231,7 +231,7 @@ export default class extends Controller {
     const currentTimeIntPart = Math.trunc(currentTime)
     const currentTimeDecimalPart = Math.round((currentTime - currentTimeIntPart) * 10)
 
-    // this is the left min part of 00:00
+    // this is the left min part of 00:00:00
     const currentTimeMinPart = Math.trunc(currentTimeIntPart / 60)
     
     if (currentTimeMinPart.toString().length == 1) {
@@ -240,7 +240,7 @@ export default class extends Controller {
       var currentTimeMinStr = String(currentTimeMinPart) // xx
     }
 
-    // this is the right sec part of 00:00
+    // this is the right sec part of 00:00:00
     const currentTimeSecPart = currentTimeIntPart - (currentTimeMinPart * 60)
 
     if (currentTimeSecPart.toString().length == 1) {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -81,8 +81,11 @@ export default class extends Controller {
     this.h_end_time_decimalTarget.value = "1"
 
     this.j_start_timeTarget.value = "00:01:25"
-    this.j_end_timeTarget.value = "00:59:10"
     this.j_start_time_decimalTarget.value = "2"
+    this.j_end_timeTarget.value = "00:59:10"
+
+    this.b_start_timeTarget.value = "00:01:59"
+    this.b_end_timeTarget.value = "00:59:10"
 
     this.m_start_timeTarget.value = "02:56"
     this.m_start_time_decimalTarget.value = "1"

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -197,12 +197,12 @@ export default class extends Controller {
     const startTimeTotalSecond = startTimeMinSecArray[0]*60 + startTimeMinSecArray[1] + startTimeDecimalNum
 
     // end time
-    const [end_m,end_s] = this.targetTime(event).end.value.split(":")
-    const endTimeMinSec = [end_m,end_s]
+    const [end_h, end_m, end_s] = this.targetTime(event).end.value.split(":")
+    const endTimeHourMinSec = [end_h, end_m, end_s]
     const endTimeDecimalStr = this.targetTime(event).end_decimal.value
     const endTimeDecimalNum = Number('0.' + endTimeDecimalStr)
-    const endTimeMinSecArray = endTimeMinSec.map( str => parseInt(str, 10))
-    const endTimeTotalSecond = endTimeMinSecArray[0]*60 + endTimeMinSecArray[1] + endTimeDecimalNum
+    const endTimeHourMinSecArray = endTimeHourMinSec.map( str => parseInt(str, 10))
+    const endTimeTotalSecond = endTimeHourMinSecArray[0] * 60 * 60 + endTimeHourMinSecArray[1] * 60 + endTimeHourMinSecArray[2] + endTimeDecimalNum
 
     // playing length
     const playingTimeTotalSecond = endTimeTotalSecond - startTimeTotalSecond

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -87,6 +87,9 @@ export default class extends Controller {
     this.b_start_timeTarget.value = "00:01:59"
     this.b_end_timeTarget.value = "00:59:10"
 
+    this.n_start_timeTarget.value = "00:00:25"
+    this.n_end_timeTarget.value = "00:59:10"
+
     this.m_start_timeTarget.value = "02:56"
     this.m_start_time_decimalTarget.value = "1"
     this.m_end_timeTarget.value = "12:00"

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -90,9 +90,9 @@ export default class extends Controller {
     this.n_start_timeTarget.value = "00:00:25"
     this.n_end_timeTarget.value = "00:59:10"
 
-    this.m_start_timeTarget.value = "02:56"
+    this.m_start_timeTarget.value = "00:02:56"
     this.m_start_time_decimalTarget.value = "1"
-    this.m_end_timeTarget.value = "12:00"
+    this.m_end_timeTarget.value = "00:59:10"
   }
 
   connect() {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -189,12 +189,12 @@ export default class extends Controller {
     if(this.frameTarget.tagName == "DIV") return
 
     // start time
-    const [m,s] = this.targetTime(event).start.value.split(":")
-    const startTimeMinSec = [m,s]
+    const [h, m, s] = this.targetTime(event).start.value.split(":")
+    const startTimeHourMinSec = [h, m, s]
     const startTimeDecimalStr = this.targetTime(event).start_decimal.value
     const startTimeDecimalNum = Number('0.' + startTimeDecimalStr)
-    const startTimeMinSecArray = startTimeMinSec.map( str => parseInt(str, 10))
-    const startTimeTotalSecond = startTimeMinSecArray[0]*60 + startTimeMinSecArray[1] + startTimeDecimalNum
+    const startTimeHourMinSecArray = startTimeHourMinSec.map( str => parseInt(str, 10))
+    const startTimeTotalSecond = startTimeHourMinSecArray[0] * 60 * 60 + startTimeHourMinSecArray[1] * 60 + startTimeHourMinSecArray[2] + startTimeDecimalNum
 
     // end time
     const [end_h, end_m, end_s] = this.targetTime(event).end.value.split(":")

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -59,10 +59,18 @@ export default class extends Controller {
 
   initialize() {
     this.element['youtube'] = this
+    
+    this.t_start_timeTarget.value = "00:01:08"
+    this.t_end_timeTarget.value = "00:59:10"
+    this.t_start_time_decimalTarget.value = "3"
 
     this.y_start_timeTarget.value = "00:00:41"
     this.y_end_timeTarget.value = "00:00:42"
     this.y_end_time_decimalTarget.value = "1"
+
+    this.u_start_timeTarget.value = "00:01:41"
+    this.u_end_timeTarget.value = "00:59:10"
+    this.u_end_time_decimalTarget.value = "1"
 
     this.j_start_timeTarget.value = "01:25"
     this.j_start_time_decimalTarget.value = "2"
@@ -71,10 +79,6 @@ export default class extends Controller {
     this.m_start_timeTarget.value = "02:56"
     this.m_start_time_decimalTarget.value = "1"
     this.m_end_timeTarget.value = "12:00"
-
-    this.t_start_timeTarget.value = "00:01:08"
-    this.t_start_time_decimalTarget.value = "3"
-    this.t_end_timeTarget.value = "00:59:10"
   }
 
   connect() {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -60,8 +60,8 @@ export default class extends Controller {
   initialize() {
     this.element['youtube'] = this
 
-    this.y_start_timeTarget.value = "00:41"
-    this.y_end_timeTarget.value = "00:42"
+    this.y_start_timeTarget.value = "00:00:41"
+    this.y_end_timeTarget.value = "00:00:42"
     this.y_end_time_decimalTarget.value = "1"
 
     this.j_start_timeTarget.value = "01:25"

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -80,9 +80,9 @@ export default class extends Controller {
     this.h_end_timeTarget.value = "00:59:10"
     this.h_end_time_decimalTarget.value = "1"
 
-    this.j_start_timeTarget.value = "01:25"
+    this.j_start_timeTarget.value = "00:01:25"
+    this.j_end_timeTarget.value = "00:59:10"
     this.j_start_time_decimalTarget.value = "2"
-    this.j_end_timeTarget.value = "02:00"
 
     this.m_start_timeTarget.value = "02:56"
     this.m_start_time_decimalTarget.value = "1"

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -76,6 +76,10 @@ export default class extends Controller {
     this.g_end_timeTarget.value = "00:59:10"
     this.g_end_time_decimalTarget.value = "1"
 
+    this.h_start_timeTarget.value = "00:02:32"
+    this.h_end_timeTarget.value = "00:59:10"
+    this.h_end_time_decimalTarget.value = "1"
+
     this.j_start_timeTarget.value = "01:25"
     this.j_start_time_decimalTarget.value = "2"
     this.j_end_timeTarget.value = "02:00"

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -231,8 +231,23 @@ export default class extends Controller {
     const currentTimeIntPart = Math.trunc(currentTime)
     const currentTimeDecimalPart = Math.round((currentTime - currentTimeIntPart) * 10)
 
-    // this is the left min part of 00:00:00
-    const currentTimeMinPart = Math.trunc(currentTimeIntPart / 60)
+    // this is the hour part of 00:00:00
+    if (currentTimeIntPart >= 3600) {
+      var currentTimeHourPart = Math.trunc(currentTimeIntPart / 3600)
+
+      if (currentTimeHourPart.toString().length == 1) {
+        var currentTimeHourStr = '0' + currentTimeHourPart // 0x
+      } else {
+        var currentTimeHourStr = String(currentTimeHourPart) // xx
+      }
+    }
+
+    // this is the min part of 00:00:00
+    if (currentTimeIntPart >= 3600) {
+      var currentTimeMinPart = Math.trunc((currentTimeIntPart / 60) - (currentTimeHourPart * 60))
+    } else {
+      var currentTimeMinPart = Math.trunc(currentTimeIntPart / 60)
+    }
     
     if (currentTimeMinPart.toString().length == 1) {
       var currentTimeMinStr = '0' + currentTimeMinPart // 0x
@@ -240,8 +255,12 @@ export default class extends Controller {
       var currentTimeMinStr = String(currentTimeMinPart) // xx
     }
 
-    // this is the right sec part of 00:00:00
-    const currentTimeSecPart = currentTimeIntPart - (currentTimeMinPart * 60)
+    // this is the sec part of 00:00:00
+    if (currentTimeIntPart >= 3600) {
+      var currentTimeSecPart = currentTimeIntPart - (currentTimeMinPart * 60) - (currentTimeHourPart * 3600)
+    } else {
+      var currentTimeSecPart = currentTimeIntPart - (currentTimeMinPart * 60)
+    }
 
     if (currentTimeSecPart.toString().length == 1) {
       var currentTimeSecStr = '0' + currentTimeSecPart // 0x
@@ -249,7 +268,11 @@ export default class extends Controller {
       var currentTimeSecStr = String(currentTimeSecPart) // xx
     }
 
-    const inputCurrentTimeIntPart = currentTimeMinStr + ':' + currentTimeSecStr
+    if (currentTimeHourStr) {
+      var inputCurrentTimeIntPart = currentTimeHourStr + ':' + currentTimeMinStr + ':' + currentTimeSecStr
+    } else {
+      var inputCurrentTimeIntPart = '00:' + currentTimeMinStr + ':' + currentTimeSecStr
+    }
 
     // const startTimeInput = event.target.closest("#dropdownHoverT")
     // const startTimeDecimalPart = event.target.closest("#dropdownHoverT")

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -289,8 +289,6 @@ export default class extends Controller {
       var inputCurrentTimeIntPart = '00:' + currentTimeMinStr + ':' + currentTimeSecStr
     }
 
-    // const startTimeInput = event.target.closest("#dropdownHoverT")
-    // const startTimeDecimalPart = event.target.closest("#dropdownHoverT")
     switch (event.target.id) {
       case 't_set_current_time_button':
         var startTimeInput = this.t_start_timeTarget

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -49,7 +49,7 @@
             <div class="p-2">
               <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="t_start_time" class="w-full icon-del font-bold ignore-keydown" value="00:00:00" type="time">
+                  <input data-youtube-target="t_start_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
@@ -57,7 +57,7 @@
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="t_end_time" class="w-full icon-del font-bold ignore-keydown" value="00:00:00" type="time">
+                  <input data-youtube-target="t_end_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -319,21 +319,21 @@
           <!-- M pad Dropdown menu -->
           <div id="dropdownHoverM" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
-              <div class="flex items-center justify-center">
+              <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="m_start_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="m_start_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="m_start_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="m_start_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="m_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="m_end_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="m_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="m_end_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
               <div class="flex items-center justify-center">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -115,21 +115,21 @@
           <!-- U pad Dropdown menu -->
           <div id="dropdownHoverU" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
-              <div class="flex items-center justify-center">
+              <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="u_start_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="u_start_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="u_start_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="u_start_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="u_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="u_end_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="u_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="u_end_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
               <div class="flex items-center justify-center">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -47,21 +47,21 @@
           <!-- T pad Dropdown menu -->
           <div id="dropdownHoverT" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
-              <div class="flex items-center justify-center">
+              <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="t_start_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="t_start_time" class="w-full icon-del font-bold ignore-keydown" value="00:00:00" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="t_start_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="t_start_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="t_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="t_end_time" class="w-full icon-del font-bold ignore-keydown" value="00:00:00" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="t_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="t_end_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
               <div class="flex items-center justify-center">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -149,21 +149,21 @@
           <!-- G pad Dropdown menu -->
           <div id="dropdownHoverG" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
-              <div class="flex items-center justify-center">
+              <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="g_start_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="g_start_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="g_start_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="g_start_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="g_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="g_end_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="g_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="g_end_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
               <div class="flex items-center justify-center">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -81,21 +81,21 @@
           <!-- Y pad Dropdown menu -->
           <div id="dropdownHoverY" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
-              <div class="flex items-center justify-center">
+              <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="y_start_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="y_start_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="y_start_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="y_start_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="y_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="y_end_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="y_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="y_end_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
               <div class="flex items-center justify-center">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -183,21 +183,21 @@
           <!-- H pad Dropdown menu -->
           <div id="dropdownHoverH" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
-              <div class="flex items-center justify-center">
+              <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="h_start_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="h_start_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="h_start_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="h_start_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="h_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="h_end_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="h_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="h_end_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
               <div class="flex items-center justify-center">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -251,21 +251,21 @@
           <!-- B pad Dropdown menu -->
           <div id="dropdownHoverB" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
-              <div class="flex items-center justify-center">
+              <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="b_start_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="b_start_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="b_start_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="b_start_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="b_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="b_end_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="b_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="b_end_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
               <div class="flex items-center justify-center">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -217,21 +217,21 @@
           <!-- J pad Dropdown menu -->
           <div id="dropdownHoverJ" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
-              <div class="flex items-center justify-center">
+              <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="j_start_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="j_start_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="j_start_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="j_start_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="j_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="j_end_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="j_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="j_end_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
               <div class="flex items-center justify-center">

--- a/app/views/shared/_pad_to_set_time.html.erb
+++ b/app/views/shared/_pad_to_set_time.html.erb
@@ -285,21 +285,21 @@
           <!-- N pad Dropdown menu -->
           <div id="dropdownHoverN" class="hidden z-50 absolute bg-white shadow-lg rounded-lg p-4 overflow-visible">
             <div class="p-2">
-              <div class="flex items-center justify-center">
+              <div>
                 <div class="flex items-end">
-                  <input data-youtube-target="n_start_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="n_start_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
                     <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="n_start_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="n_start_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
                 <div class="px-2">〜</div>
                 <div class="flex items-end">
-                  <input data-youtube-target="n_end_time" class="w-18 icon-del font-bold ignore-keydown" value="00:00" type="time">
+                  <input data-youtube-target="n_end_time" class="w-full icon-del font-bold ignore-keydown" type="time">
                   <div class="px-2">
-                    <div class="font-Mold text-3xl">.</div>
+                    <div class="font-bold text-3xl">.</div>
                   </div>
-                  <input data-youtube-target="n_end_time_decimal" class="w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
+                  <input data-youtube-target="n_end_time_decimal" class="text-center w-10 icon-del font-bold ignore-keydown" value="0" type="text" maxlength="1">
                 </div>
               </div>
               <div class="flex items-center justify-center">


### PR DESCRIPTION
## 概要
本来`input type="time"`はHH:MMで、左右をそれぞれ[m,s]という配列として取り出して分秒としていましたが、HH:MMのHHは書式の制限上`23`までしか入力ができない（24時間以上になってしまうため）ため、結果的に23分より上の指定が出来ませんでした。

そこで、`input type="time"`をHH:MM:SSまで入力できるようにして、[h,m,s]にそれぞれを取り出して時分秒を設定できるように修正しました。　こうすることで、書式だと`23:59:59`まで入力できるので分がきちんと59まで入力出来るようになり、23以上を入力できない問題を解決しました。

## 変更点
- `input type="time"`が`HH:MM`なのを`HH:MM:SS`になるように`initialize()`でデフォルトの値を変更
- `HH:MM:SS`に合わせて各メソッドの処理を一部変更
- if文の条件式が重複していたのでswitch文にしてリファクタリング