### PR TITLE
Feature/add column video title

### DIFF
--- a/db/migrate/20250504130618_add_video_title_to_youtube.rb
+++ b/db/migrate/20250504130618_add_video_title_to_youtube.rb
@@ -1,0 +1,5 @@
+class AddVideoTitleToYoutube < ActiveRecord::Migration[7.2]
+  def change
+    add_column :youtubes, :video_title, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,7 +61,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_03_130641) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "username"
+    t.string "username", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_03_130641) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_04_130618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,7 +61,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_03_130641) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "username", null: false
+    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -71,6 +71,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_03_130641) do
     t.bigint "beat_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "video_title", null: false
     t.index ["beat_id"], name: "index_youtubes_on_beat_id"
   end
 

--- a/test/fixtures/youtubes.yml
+++ b/test/fixtures/youtubes.yml
@@ -2,8 +2,10 @@
 
 one:
   video_id: MyString
+  video_title: "first_video"
   beat: one
 
 two:
   video_id: MyString
+  video_title: "second_video"
   beat: two


### PR DESCRIPTION
## 概要
ビート一覧画面にyoutubeのタイトルを表示する必要が生じたため、youtubesテーブルにvideo_titleのカラムを追加しました。