### PR TITLE
Feature/beats input form modal UI

### DIFF
--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -1,0 +1,3 @@
+class BeatsController < ApplicationController
+  def new ;end
+end

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -1,3 +1,2 @@
 class BeatsController < ApplicationController
-  def new ;end
 end

--- a/app/views/beats/new.html.erb
+++ b/app/views/beats/new.html.erb
@@ -1,1 +1,0 @@
-<div>this is beats/new.html.erb</div>

--- a/app/views/beats/new.html.erb
+++ b/app/views/beats/new.html.erb
@@ -1,0 +1,1 @@
+<div>this is beats/new.html.erb</div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -9,7 +9,38 @@
         <input type="range" id="bpm" min="60" max="240" value="94" data-action="input->step-sequencer#currentBPM" data-step-sequencer-target="bpm">
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#playSequencer">Play</button>
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#stopSequencer">Stop</button>
-        <%= link_to "save this beat", new_beat_path, class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded" %>
+        <button data-modal-target="SaveThisBeatModal" data-modal-toggle="SaveThisBeatModal" class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded">
+        save this beat
+        </button>
+        <!-- Modal -->
+        <div id="SaveThisBeatModal" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto h-screen bg-black/50 backdrop-blur">
+          <div class="w-full">
+            <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto my-auto">
+              <div class="bg-white  shadow-lg rounded-lg px-12 w-2/5">
+                <div class="flex items-center justify-center p-4">
+                  <p class="pt-8 font-bold text-xl text-gray-800">Let's save this beat!</p>
+                </div>
+                <div class="p-4">
+                  <%= form_with model: @beat, local: true do |f| %>
+                    <div>
+                      <div class="px-4 pb-4">
+                        <%= f.label :title %>
+                        <%= f.text_field :title, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" %>
+                      </div>
+                      <div class="p-4">
+                        <div class="flex justify-center">
+                          <button class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700">
+                            <%= f.submit "save", class: "text-white font-medium" %>
+                          </button>
+                        </div>
+                      </div>
+                    </div>  
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
         <!-- Modal toggle -->
         <div class="mb-1 w-[16px] px-2">
             <div id="resetStepsActiveButton" data-modal-target="deleteStepsModal" data-modal-toggle="deleteStepsModal" type="button">

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -9,6 +9,7 @@
         <input type="range" id="bpm" min="60" max="240" value="94" data-action="input->step-sequencer#currentBPM" data-step-sequencer-target="bpm">
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#playSequencer">Play</button>
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#stopSequencer">Stop</button>
+        <%= link_to "save this beat", new_beat_path, class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded" %>
         <!-- Modal toggle -->
         <div class="mb-1 w-[16px] px-2">
             <div id="resetStepsActiveButton" data-modal-target="deleteStepsModal" data-modal-toggle="deleteStepsModal" type="button">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -46,38 +46,3 @@
     </div>
   </div>
 </div>
-
-<% if false %>
-  <div class="border border-black">
-    <h2>Sign up test</h2>
-    <div>
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-        <%= render "devise/shared/error_messages", resource: resource %>
-
-        <div class="field">
-          <%= f.label :email %><br />
-          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-        </div>
-
-        <div class="field">
-          <%= f.label :password %>
-          <% if @minimum_password_length %>
-          <em>(<%= @minimum_password_length %> characters minimum)</em>
-          <% end %><br />
-          <%= f.password_field :password, autocomplete: "new-password" %>
-        </div>
-
-        <div class="field">
-          <%= f.label :password_confirmation %><br />
-          <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-        </div>
-
-        <div class="actions">
-          <%= f.submit "Sign up" %>
-        </div>
-      <% end %>
-
-      <%= render "devise/shared/links" %>
-    </div>
-  </div>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
     passwords: "users/passwords",
     confirmations: "users/confirmations"
   }
+  
+  resources :beats
+
   get "top/index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     confirmations: "users/confirmations"
   }
   
-  resources :beats
+  resources :beats, except: %i[ new ]
 
   get "top/index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## 概要
トップページに「Save this beat」というボタンを配置し、クリックするとビート新規作成のためのフォームが表示されるようなモーダルを新規作成しました。

## 変更点
・beats_controllerの作成
・beatsのルーティング（今回は新規作成画面のbeats#newを用いず、モーダルのフォームから直接beats#createを実行するようにするため、`except: %i[ new ]`としnewアクションを除外しました。）
・元々はテスト用で使っていましたが現在は使用していないコードを削除しました（`app/views/users/registrations/new.html.erb`）

## 確認方法

1. トップページ(`/`)にアクセス
2. シーケンサーの上にある`Save this beat`をクリック
3. フォームがモーダルで表示されるのが確認できます