### PR TITLE
Feature/set the sequencer data to save

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -14,6 +14,7 @@ export default class extends Controller {
                     "current_snare",
                     "current_kick",
                     "indicator",
+                    "pads_volume",
                     "hihats_volume",
                     "snares_volume",
                     "kicks_volume",

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -185,7 +185,8 @@ export default class extends Controller {
       pads_assigned: padsAssignedStr,
       pad_active_index: padActiveIndexStr,
       youtube_volume: this.stepSequencerOutlet.pads_volumeTarget.value,
-      hihats_volume: this.stepSequencerOutlet.hihats_volumeTarget.value
+      hihats_volume: this.stepSequencerOutlet.hihats_volumeTarget.value,
+      snares_volume: this.stepSequencerOutlet.snares_volumeTarget.value
     }
   }
 

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -160,6 +160,7 @@ export default class extends Controller {
     }
 
     const sequencer_data_to_save = {
+      bpm: Number(this.stepSequencerOutlet.bpmTarget.value),
       hihats_active_index: hihatsActiveStr,
       snares_active_index: snaresActiveStr,
       kicks_active_index: kicksActiveStr

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -184,7 +184,8 @@ export default class extends Controller {
       kicks_active_index: kicksActiveStr,
       pads_assigned: padsAssignedStr,
       pad_active_index: padActiveIndexStr,
-      youtube_volume: this.stepSequencerOutlet.pads_volumeTarget.value
+      youtube_volume: this.stepSequencerOutlet.pads_volumeTarget.value,
+      hihats_volume: this.stepSequencerOutlet.hihats_volumeTarget.value
     }
   }
 

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -155,13 +155,17 @@ export default class extends Controller {
     const padsStepsArray = stepsArray.slice(16,32)
     const padsAssignedArray = []
 
+    const padActiveIndexArray = []
+
     padsStepsArray.forEach((step) => {
       if (['T','Y','U','G','H','J','B','N','M'].includes(step.firstElementChild.value)) {
         padsAssignedArray.push(step.firstElementChild.value)
+        padActiveIndexArray.push(step.getAttribute('index'))
       }
     })
 
     const padsAssignedStr = padsAssignedArray.toString()
+    const padActiveIndexStr = padActiveIndexArray.toString()
 
     // data_to_save
     const youtube_data_to_save = {
@@ -178,7 +182,8 @@ export default class extends Controller {
       hihats_active_index: hihatsActiveStr,
       snares_active_index: snaresActiveStr,
       kicks_active_index: kicksActiveStr,
-      pads_assigned: padsAssignedStr
+      pads_assigned: padsAssignedStr,
+      pad_active_index: padActiveIndexStr
     }
   }
 

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -186,7 +186,8 @@ export default class extends Controller {
       pad_active_index: padActiveIndexStr,
       youtube_volume: this.stepSequencerOutlet.pads_volumeTarget.value,
       hihats_volume: this.stepSequencerOutlet.hihats_volumeTarget.value,
-      snares_volume: this.stepSequencerOutlet.snares_volumeTarget.value
+      snares_volume: this.stepSequencerOutlet.snares_volumeTarget.value,
+      kicks_volume: this.stepSequencerOutlet.kicks_volumeTarget.value
     }
   }
 

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -151,7 +151,19 @@ export default class extends Controller {
     const snaresActiveStr = hihatsActiveArray.toString()
     const kicksActiveStr = hihatsActiveArray.toString()
 
+    // pads_assigned
+    const padsStepsArray = stepsArray.slice(16,32)
+    const padsAssignedArray = []
 
+    padsStepsArray.forEach((step) => {
+      if (['T','Y','U','G','H','J','B','N','M'].includes(step.firstElementChild.value)) {
+        padsAssignedArray.push(step.firstElementChild.value)
+      }
+    })
+
+    const padsAssignedStr = padsAssignedArray.toString()
+
+    // data_to_save
     const youtube_data_to_save = {
       video_title: this.getPlayer.getVideoData().title,
       video_id: this.getPlayer.getVideoData().video_id
@@ -165,7 +177,8 @@ export default class extends Controller {
       bpm: Number(this.stepSequencerOutlet.bpmTarget.value),
       hihats_active_index: hihatsActiveStr,
       snares_active_index: snaresActiveStr,
-      kicks_active_index: kicksActiveStr
+      kicks_active_index: kicksActiveStr,
+      pads_assigned: padsAssignedStr
     }
   }
 

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -183,7 +183,8 @@ export default class extends Controller {
       snares_active_index: snaresActiveStr,
       kicks_active_index: kicksActiveStr,
       pads_assigned: padsAssignedStr,
-      pad_active_index: padActiveIndexStr
+      pad_active_index: padActiveIndexStr,
+      youtube_volume: this.stepSequencerOutlet.pads_volumeTarget.value
     }
   }
 

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -114,6 +114,7 @@ export default class extends Controller {
   }
 
   setTheDataToSave () {
+    // hihats_active_index, snares_active_index, kicks_active_index
     const stepsCollection = this.stepSequencerOutlet.gridTarget.children
     const stepsArray = Array.prototype.slice.call(stepsCollection)
     const drumsStepsArray = stepsArray.slice(32,80)
@@ -146,9 +147,10 @@ export default class extends Controller {
       }
     })
 
-    hihatsActiveStr = hihatsActiveArray.toString()
-    snaresActiveStr = hihatsActiveArray.toString()
-    kicksActiveStr = hihatsActiveArray.toString()
+    const hihatsActiveStr = hihatsActiveArray.toString()
+    const snaresActiveStr = hihatsActiveArray.toString()
+    const kicksActiveStr = hihatsActiveArray.toString()
+
 
     const youtube_data_to_save = {
       video_title: this.getPlayer.getVideoData().title,

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -71,7 +71,7 @@
         <div class="mt-8">
           <div class="grid grid-cols-1 gap-8">
             <div>
-              <input type="range" value="20" min="0" max="100" step="1" data-action="youtube#padVolumeControl" data-youtube-target="pads_volume" class="mr-4">
+              <input type="range" value="20" min="0" max="100" step="1" data-action="youtube#padVolumeControl" data-step-sequencer-target="pads_volume" class="mr-4">
             </div>
             <div>
               <input type="range" value="-0.91" min="-1" max="1" step="0.01" data-action="step-sequencer#hihatVolumeControl" data-step-sequencer-target="hihats_volume" class="mr-4">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,7 +63,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_05_153044) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "username"
+    t.string "username", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
`sequencer_data_to_save`オブジェクトに必要なデータを追加しました。

## 変更点
・`pads_volume`のターゲットを取ることを失念していたため、追加
・`pads_assigned`のデータに必要な整形の処理を追加
・`sequencer_data_to_save`に必要なキーと値を追加