### PR TITLE
Feature/validate beat data

### DIFF
--- a/app/javascript/controllers/beat_controller.js
+++ b/app/javascript/controllers/beat_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
 
   static targets = [
 
-    "beat_title",
+    "beat_title_field",
     "save_button",
     "hidden_beats_data_field",
     "hidden_youtubes_data_field",
@@ -91,7 +91,7 @@ export default class extends Controller {
     }
 
     const beat_title_data_to_save = {
-      title: this.beat_titleTarget.value
+      title: this.beat_title_fieldTarget.value
     }
 
     const sequencer_data_to_save = {

--- a/app/models/beat.rb
+++ b/app/models/beat.rb
@@ -1,4 +1,6 @@
 class Beat < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 50 }
+
   has_one :youtube
   has_one :pad_timing
   has_one :sequencer

--- a/app/models/pad_timing.rb
+++ b/app/models/pad_timing.rb
@@ -1,3 +1,13 @@
 class PadTiming < ApplicationRecord
+  validates :t_time, presence: true
+  validates :y_time, presence: true
+  validates :u_time, presence: true
+  validates :g_time, presence: true
+  validates :h_time, presence: true
+  validates :j_time, presence: true
+  validates :b_time, presence: true
+  validates :n_time, presence: true
+  validates :m_time, presence: true
+
   belongs_to :beat
 end

--- a/app/models/sequencer.rb
+++ b/app/models/sequencer.rb
@@ -1,3 +1,14 @@
 class Sequencer < ApplicationRecord
+  validates :bpm, presence: true
+  validates :hihats_active_index, presence: true
+  validates :snares_active_index, presence: true
+  validates :kicks_active_index, presence: true
+  validates :pads_assigned, presence: true
+  validates :pad_active_index, presence: true
+  validates :youtube_volume, presence: true
+  validates :hihat_volume, presence: true
+  validates :snare_volume, presence: true
+  validates :kick_volume, presence: true
+
   belongs_to :beat
 end

--- a/app/models/youtube.rb
+++ b/app/models/youtube.rb
@@ -1,3 +1,6 @@
 class Youtube < ApplicationRecord
+  validates :video_title, presence: true
+  validates :video_id, presence: true
+
   belongs_to :beat
 end

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -24,7 +24,7 @@
                   <%= form_with url: '/beats', method: :post do |f| %>
                     <div class="px-4 pb-4">
                       <%= f.label :beat_title %>
-                      <%= f.text_field :beat_title, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"} %>
+                      <%= f.text_field :beat_title, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"} %>
                       <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
                       <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
                       <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -24,7 +24,7 @@
                   <%= form_with url: '/beats', method: :post do |f| %>
                     <div class="px-4 pb-4">
                       <%= f.label :beat_title %>
-                      <%= f.text_field :beat_title, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"} %>
+                      <%= f.text_field :beat_title, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50" %>
                       <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
                       <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
                       <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>


### PR DESCRIPTION
## 概要
`Beat`, `Youtube`, `Sequencer`, `PadTiming`モデルにバリデーションを追加しました。

## 変更点
・`Beat`モデルの`title`カラムに対して`presence: true`と`length: { maximum: 50 }`を追加
・`Beat`モデルまたは子モデルの各カラムに`presence: true`を追加
・フォームのtext_fieldにも`maxlength: "50"`として最大文字数の制限を与えました。