### PR TITLE
Feature/create the beat

### DIFF
--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -1,6 +1,10 @@
 class BeatsController < ApplicationController
   def create
     ActiveRecord::Base.transaction do
+      beats_data_json = JSON.parse(beat_params[:beats_data])
+      youtubes_data_json = JSON.parse(beat_params[:youtubes_data])
+      sequencers_data_json = JSON.parse(beat_params[:sequencers_data])
+      pad_timings_data_json = JSON.parse(beat_params[:pad_timings_data])
     end
   end
 

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -5,6 +5,8 @@ class BeatsController < ApplicationController
       youtubes_data_json = JSON.parse(beat_params[:youtubes_data])
       sequencers_data_json = JSON.parse(beat_params[:sequencers_data])
       pad_timings_data_json = JSON.parse(beat_params[:pad_timings_data])
+
+      raise if beats_data_json["title"].blank?
     end
   end
 

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -1,4 +1,8 @@
 class BeatsController < ApplicationController
+  def create
+    ActiveRecord::Base.transaction do
+    end
+  end
 
   private
 

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -6,7 +6,16 @@ class BeatsController < ApplicationController
       sequencers_data_json = JSON.parse(beat_params[:sequencers_data])
       pad_timings_data_json = JSON.parse(beat_params[:pad_timings_data])
 
-      raise if beats_data_json["title"].blank?
+      # raise if beats_data_json["title"].blank?
+
+      @beat = current_user.beats.new(beats_data_json)
+      @beat.save!
+
+      @beat.create_youtube!(youtubes_data_json)
+
+      @beat.create_sequencer!(sequencers_data_json)
+
+      @beat.create_pad_timing!(pad_timings_data_json)
     end
   end
 

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -3,6 +3,6 @@ class BeatsController < ApplicationController
   private
 
   def beat_params
-    params.permit(:beat_title, :beats_data, :youtubes_data, :sequencers_data, :pad_timings_data)
+    params.require(:beat).permit(:beat_title, :beats_data, :youtubes_data, :sequencers_data, :pad_timings_data)
   end
 end

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -1,2 +1,8 @@
 class BeatsController < ApplicationController
+
+  private
+
+  def beat_params
+    params.permit(:beat_title, :beats_data, :youtubes_data, :sequencers_data, :pad_timings_data)
+  end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,3 +1,5 @@
 class TopController < ApplicationController
-  def index; end
+  def index
+    @beat = Beat.new
+  end
 end

--- a/app/javascript/controllers/beat_controller.js
+++ b/app/javascript/controllers/beat_controller.js
@@ -130,13 +130,14 @@ export default class extends Controller {
     return data_to_save
   }
 
-  createTheBeat (event) {
+  createTheBeat () {
     const data_to_save = this.setTheDataToSave()
 
     this.hidden_beats_data_fieldTarget.value = JSON.stringify(data_to_save.beats)
     this.hidden_youtubes_data_fieldTarget.value = JSON.stringify(data_to_save.youtubes)
     this.hidden_sequencers_data_fieldTarget.value = JSON.stringify(data_to_save.sequencers)
     this.hidden_pad_timings_data_fieldTarget.value = JSON.stringify(data_to_save.pad_timings)
-    // this.event.requestSubmit()
+
+    this.beat_save_formTarget.requestSubmit()
   }
 }

--- a/app/javascript/controllers/beat_controller.js
+++ b/app/javascript/controllers/beat_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
     "hidden_youtubes_data_field",
     "hidden_sequencers_data_field",
     "hidden_pad_timings_data_field",
+    "beat_save_form"
 
   ]
 

--- a/app/javascript/controllers/beat_controller.js
+++ b/app/javascript/controllers/beat_controller.js
@@ -103,9 +103,9 @@ export default class extends Controller {
       pads_assigned: padsAssignedStr,
       pad_active_index: padActiveIndexStr,
       youtube_volume: this.stepSequencerOutlet.pads_volumeTarget.value,
-      hihats_volume: this.stepSequencerOutlet.hihats_volumeTarget.value,
-      snares_volume: this.stepSequencerOutlet.snares_volumeTarget.value,
-      kicks_volume: this.stepSequencerOutlet.kicks_volumeTarget.value
+      hihat_volume: this.stepSequencerOutlet.hihats_volumeTarget.value,
+      snare_volume: this.stepSequencerOutlet.snares_volumeTarget.value,
+      kick_volume: this.stepSequencerOutlet.kicks_volumeTarget.value
     }
 
     const pad_timings_data_to_save = {

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -21,7 +21,7 @@
                   <p class="pt-8 font-bold text-xl text-gray-800">Let's save this beat!</p>
                 </div>
                 <div class="p-4">
-                  <%= form_with url: '/beats', method: :post, data: { beat_target: "beat_save_form" } do |f| %>
+                  <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
                     <div class="px-4 pb-4">
                       <%= f.label :beat_title %>
                       <%= f.text_field :beat_title, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50" %>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -24,7 +24,7 @@
                   <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
                     <div class="px-4 pb-4">
                       <%= f.label :beat_title %>
-                      <%= f.text_field :beat_title, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50" %>
+                      <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50" %>
                       <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
                       <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
                       <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -21,7 +21,7 @@
                   <p class="pt-8 font-bold text-xl text-gray-800">Let's save this beat!</p>
                 </div>
                 <div class="p-4">
-                  <%= form_with url: '/beats', method: :post do |f| %>
+                  <%= form_with url: '/beats', method: :post, data: { beat_target: "beat_save_form" } do |f| %>
                     <div class="px-4 pb-4">
                       <%= f.label :beat_title %>
                       <%= f.text_field :beat_title, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50" %>


### PR DESCRIPTION
## 概要
top#indexの`Save`ボタンをクリックすると、DBの`beats`, `youtubes`, `sequencers`, `pad_timings`テーブルにレコードが新規作成されるようにしました。
（※現段階ではトランザクション成功時・例外時の処理はまだ記述しておらず、保存のみの処理となっています）

## 変更点
・保存するためのデータを格納するオブジェクトのキーがDBのカラム名と対応が取れていなかったため、修正しました。　`app/javascript/controllers/beat_controller.js 105 - 108`

・モーダルのフォームでのtext_fieldに対してキーボードの打鍵を行うと、`keydown.t@document->youtube#play`によってyoutubeが再生してしまう問題が発生していたため、`ignore-keydown`をclassに追加しました。（ignore-keydownがclassにあると、その再生の処理が行わないような処理を既に記述済み）

・paramsに`Unpermitted parameter: :authenticity_token.`という警告が発生していたため、フォームに`model: @beat`を追加し、top#indexに`@beat = Beat.new`を追加

・`beats#create`にてDBの`beats`, `youtubes`, `sequencers`, `pad_timings`テーブルにレコードが新規作成される処理を追加