### PR TITLE
Feature/logic after transaction successed or failed

### DIFF
--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -19,7 +19,8 @@ class BeatsController < ApplicationController
     end
     redirect_to mybeats_beats_path, notice: 'The beat was saved successfully.'
   rescue ActiveRecord::RecordInvalid => e
-    render "top/index", status: :unprocessable_entity
+    flash.now[:danger] = "The beat could not be saved."
+    render partial: "shared/beats/form", status: :unprocessable_entity
   end
 
   def mybeats

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -19,6 +19,10 @@ class BeatsController < ApplicationController
     end
   end
 
+  def mybeats
+    
+  end
+
   private
 
   def beat_params

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -17,14 +17,13 @@ class BeatsController < ApplicationController
 
       @beat.create_pad_timing!(pad_timings_data_json)
     end
-    redirect_to mybeats_beats_path, notice: 'The beat was saved successfully.'
+    redirect_to mybeats_beats_path, notice: "The beat was saved successfully."
   rescue ActiveRecord::RecordInvalid => e
     flash.now[:danger] = "The beat could not be saved."
     render partial: "shared/beats/form", status: :unprocessable_entity
   end
 
   def mybeats
-
   end
 
   private

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -18,6 +18,8 @@ class BeatsController < ApplicationController
       @beat.create_pad_timing!(pad_timings_data_json)
     end
     redirect_to mybeats_beats_path, notice: 'The beat was saved successfully.'
+  rescue ActiveRecord::RecordInvalid => e
+    render "top/index", status: :unprocessable_entity
   end
 
   def mybeats

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -17,10 +17,11 @@ class BeatsController < ApplicationController
 
       @beat.create_pad_timing!(pad_timings_data_json)
     end
+    redirect_to mybeats_beats_path, notice: 'The beat was saved successfully.'
   end
 
   def mybeats
-    
+
   end
 
   private

--- a/app/javascript/controllers/beat_controller.js
+++ b/app/javascript/controllers/beat_controller.js
@@ -18,6 +18,16 @@ export default class extends Controller {
   static outlets = [ "step-sequencer", "youtube" ]
 
   connect() {
+    // re-open the modal after the turbo-frame is re-rendered
+    // caution:  When using Flowbite, simply removing the hidden class does not show the modal.
+    // you must use modalElement.show() method.
+    document.addEventListener('turbo:frame-render', (event) => {
+      if (event.target.id === "save_beat_form") {
+        const modalElement = document.getElementById("SaveThisBeatModal")
+        const modal = new Modal(modalElement)
+        modal.show()
+      }
+    })
   }
 
   setTheDataToSave () {

--- a/app/views/beats/mybeats.html.erb
+++ b/app/views/beats/mybeats.html.erb
@@ -1,0 +1,1 @@
+<div>This is a MyBeats page.</div>

--- a/app/views/beats/mybeats.html.erb
+++ b/app/views/beats/mybeats.html.erb
@@ -1,1 +1,11 @@
+<div>
+  <% if flash[:notice] %>
+    <div class="flex items-center p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+      <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+        <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+      </svg>
+      <div class="alert alert-success"><%= notice %></div>
+    </div>
+  <% end %>
+</div>
 <div>This is a MyBeats page.</div>

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -13,34 +13,7 @@
         save this beat
         </button>
         <!-- Modal -->
-        <div data-controller="beat" data-beat-step-sequencer-outlet="#step-sequencer" data-beat-youtube-outlet="#youtube" id="SaveThisBeatModal" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto h-screen bg-black/50 backdrop-blur">
-          <div class="w-full">
-            <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto my-auto">
-              <div class="bg-white  shadow-lg rounded-lg px-12 w-2/5">
-                <div class="flex items-center justify-center p-4">
-                  <p class="pt-8 font-bold text-xl text-gray-800">Let's save this beat!</p>
-                </div>
-                <div class="p-4">
-                  <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
-                    <div class="px-4 pb-4">
-                      <%= f.label :beat_title %>
-                      <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50" %>
-                      <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
-                      <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
-                      <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>
-                      <%= f.hidden_field :pad_timings_data, data: { beat_target: "hidden_pad_timings_data_field" } %>
-                    </div>
-                    <div class="p-4">
-                      <div class="flex justify-center">
-                        <%= button_tag 'Save', type: 'button',class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold py-2 px-4 rounded", data: { beat_target: "save_button", action: "click->beat#createTheBeat" } %>
-                      </div>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        <%= render 'shared/beats/form', beat: @beat %>
         <!-- Modal toggle -->
         <div class="mb-1 w-[16px] px-2">
             <div id="resetStepsActiveButton" data-modal-target="deleteStepsModal" data-modal-toggle="deleteStepsModal" type="button">

--- a/app/views/shared/beats/_form.html.erb
+++ b/app/views/shared/beats/_form.html.erb
@@ -1,0 +1,30 @@
+<%= turbo_frame_tag "save_beat_form" do %>
+  <div data-controller="beat" data-beat-step-sequencer-outlet="#step-sequencer" data-beat-youtube-outlet="#youtube" id="SaveThisBeatModal" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto h-screen bg-black/50 backdrop-blur">
+    <div class="w-full">
+      <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto my-auto">
+        <div class="bg-white  shadow-lg rounded-lg px-12 w-2/5">
+          <div class="flex items-center justify-center p-4">
+            <p class="pt-8 font-bold text-xl text-gray-800">Let's save this beat!</p>
+          </div>
+          <div class="p-4">
+            <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
+              <div class="px-4 pb-4">
+                <%= f.label :beat_title %>
+                <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50" %>
+                <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
+                <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
+                <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>
+                <%= f.hidden_field :pad_timings_data, data: { beat_target: "hidden_pad_timings_data_field" } %>
+              </div>
+              <div class="p-4">
+                <div class="flex justify-center">
+                  <%= button_tag 'Save', type: 'button',class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold py-2 px-4 rounded", data: { beat_target: "save_button", action: "click->beat#createTheBeat" } %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/beats/_form.html.erb
+++ b/app/views/shared/beats/_form.html.erb
@@ -2,13 +2,21 @@
   <div data-controller="beat" data-beat-step-sequencer-outlet="#step-sequencer" data-beat-youtube-outlet="#youtube" id="SaveThisBeatModal" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto h-screen bg-black/50 backdrop-blur">
     <div class="w-full">
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto my-auto">
-        <div class="bg-white  shadow-lg rounded-lg px-12 w-2/5">
+        <div class="bg-white  shadow-lg rounded-lg px-12 w-1/2">
           <div class="flex items-center justify-center p-4">
             <p class="pt-8 font-bold text-xl text-gray-800">Let's save this beat!</p>
           </div>
           <div class="p-4">
             <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
               <div class="px-4 pb-4">
+                <% if flash[:danger] %>
+                  <div class="flex justify-center items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+                    <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                      <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+                    </svg>
+                    <div class="alert alert-danger w-full"><%= flash[:danger] %></div>
+                  </div>
+                <% end %>
                 <%= f.label :beat_title %>
                 <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50" %>
                 <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
     confirmations: "users/confirmations"
   }
 
-  resources :beats, except: %i[ new ]
+  resources :beats, except: %i[ new ] do
+    get "mybeats", on: :collection
+  end
 
   get "top/index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## 概要
ビート新規作成（保存）のトランザクション処理の成功後、自分が作って保存したビートの一覧画面(`beats/mybeats`)にリダイレクトをするようにしました。
その時、成功のフラッシュメッセージを表示するようにしています。

ビート新規作成（保存）のトランザクション処理の例外発生後、ビート新規作成のためのフォームをturbo-frameを用いて再描画しました。
その時、エラーのフラッシュメッセージを表示するようにしています。

## 変更点
・`beats/mybeats`のルーティングを`colleciton`を用いて追加
・beatsコントローラーにmybeatsアクションを追加
・`views/beats/mybeats.html.erb`の新規作成

・トランザクション成功時、`redirect_to mybeats_beats_path, notice: 'The beat was saved successfully.'`でリダイレクトと`flash[:notice]`にメッセージを持たせる処理を追加

・`top/index.html.erb`のビート新規作成のためのフォームの箇所を`shared/beats/_form.html.erb`に切り出し、`turbo_frame_tag`で囲みました。
・フォームにトランザクション失敗時のフラッシュメッセージを表示するための処理を追加

・トランザクション失敗時、`rescue ActiveRecord::RecordInvalid => e`でトランザクションの外で例外をキャッチ（トランザクションの内部で`rescue`を行うと、ロールバックが実行されないようです）

・トランザクション失敗時、`shared/beats/_form.html.erb`を再描画する処理を追加。　flash.now[:danger]に表示したいメッセージを格納。

・turbo-frameで再描画した後に、モーダルを再表示する処理を追加（この処理を行わないと、再描画時にモーダルが表示されない。 今回のflowbiteを用いている場合は、提供されているメソッドである`show()`をモーダルのエレメントで使うことでモーダルの再表示が出来る。）