### PR TITLE
Fix/turboframe missing error

### DIFF
--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -6,8 +6,6 @@ class BeatsController < ApplicationController
       sequencers_data_json = JSON.parse(beat_params[:sequencers_data])
       pad_timings_data_json = JSON.parse(beat_params[:pad_timings_data])
 
-      # raise if beats_data_json["title"].blank?
-
       @beat = current_user.beats.new(beats_data_json)
       @beat.save!
 

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -18,7 +18,10 @@ class BeatsController < ApplicationController
     redirect_to mybeats_beats_path, notice: "The beat was saved successfully."
   rescue ActiveRecord::RecordInvalid => e
     flash.now[:danger] = "The beat could not be saved."
-    render partial: "shared/beats/form", status: :unprocessable_entity
+    render turbo_stream: turbo_stream.replace(
+      "error_messages",
+      render_to_string(partial: "shared/danger")
+    ), status: :unprocessable_entity
   end
 
   def mybeats

--- a/app/views/shared/_danger.html.erb
+++ b/app/views/shared/_danger.html.erb
@@ -1,0 +1,8 @@
+<% if flash[:danger] %>
+  <div class="flex justify-center items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+    <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+      <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+    </svg>
+    <div class="alert alert-danger w-full"><%= flash[:danger] %></div>
+  </div>
+<% end %>

--- a/app/views/shared/beats/_form.html.erb
+++ b/app/views/shared/beats/_form.html.erb
@@ -1,4 +1,3 @@
-<%= turbo_frame_tag "save_beat_form" do %>
   <div data-controller="beat" data-beat-step-sequencer-outlet="#step-sequencer" data-beat-youtube-outlet="#youtube" id="SaveThisBeatModal" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto h-screen bg-black/50 backdrop-blur">
     <div class="w-full">
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto my-auto">
@@ -7,32 +6,33 @@
             <p class="pt-8 font-bold text-xl text-gray-800">Let's save this beat!</p>
           </div>
           <div class="p-4">
-            <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
-              <div class="px-4 pb-4">
-                <% if flash[:danger] %>
-                  <div class="flex justify-center items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-                    <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
-                      <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
-                    </svg>
-                    <div class="alert alert-danger w-full"><%= flash[:danger] %></div>
-                  </div>
-                <% end %>
-                <%= f.label :beat_title %>
-                <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 placeholder-gray-500 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50", placeholder: 'Please enter a beat title' %>
-                <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
-                <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
-                <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>
-                <%= f.hidden_field :pad_timings_data, data: { beat_target: "hidden_pad_timings_data_field" } %>
-              </div>
-              <div class="p-4">
-                <div class="flex justify-center">
-                  <%= button_tag 'Save', type: 'button', class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold py-2 px-4 rounded", data: { beat_target: "save_button", action: "click->beat#createTheBeat" } %>
+            <%= turbo_frame_tag "save_beat_form" do %>
+              <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
+                <div class="px-4 pb-4">
+                  <% if flash[:danger] %>
+                    <div class="flex justify-center items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+                      <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+                      </svg>
+                      <div class="alert alert-danger w-full"><%= flash[:danger] %></div>
+                    </div>
+                  <% end %>
+                  <%= f.label :beat_title %>
+                  <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 placeholder-gray-500 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50", placeholder: 'Please enter a beat title' %>
+                  <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
+                  <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
+                  <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>
+                  <%= f.hidden_field :pad_timings_data, data: { beat_target: "hidden_pad_timings_data_field" } %>
                 </div>
-              </div>
+                <div class="p-4">
+                  <div class="flex justify-center">
+                    <%= button_tag 'Save', type: 'button', class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold py-2 px-4 rounded", data: { beat_target: "save_button", action: "click->beat#createTheBeat" } %>
+                  </div>
+                </div>
+              <% end %>
             <% end %>
           </div>
         </div>
       </div>
     </div>
   </div>
-<% end %>

--- a/app/views/shared/beats/_form.html.erb
+++ b/app/views/shared/beats/_form.html.erb
@@ -18,7 +18,7 @@
                   </div>
                 <% end %>
                 <%= f.label :beat_title %>
-                <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50" %>
+                <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 placeholder-gray-500 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50", placeholder: 'Please enter a beat title' %>
                 <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
                 <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
                 <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>
@@ -26,7 +26,7 @@
               </div>
               <div class="p-4">
                 <div class="flex justify-center">
-                  <%= button_tag 'Save', type: 'button',class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold py-2 px-4 rounded", data: { beat_target: "save_button", action: "click->beat#createTheBeat" } %>
+                  <%= button_tag 'Save', type: 'button', class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold py-2 px-4 rounded", data: { beat_target: "save_button", action: "click->beat#createTheBeat" } %>
                 </div>
               </div>
             <% end %>

--- a/app/views/shared/beats/_form.html.erb
+++ b/app/views/shared/beats/_form.html.erb
@@ -6,30 +6,23 @@
             <p class="pt-8 font-bold text-xl text-gray-800">Let's save this beat!</p>
           </div>
           <div class="p-4">
-            <%= turbo_frame_tag "save_beat_form" do %>
-              <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
-                <div class="px-4 pb-4">
-                  <% if flash[:danger] %>
-                    <div class="flex justify-center items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-                      <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
-                      </svg>
-                      <div class="alert alert-danger w-full"><%= flash[:danger] %></div>
-                    </div>
-                  <% end %>
-                  <%= f.label :beat_title %>
-                  <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 placeholder-gray-500 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50", placeholder: 'Please enter a beat title' %>
-                  <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
-                  <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
-                  <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>
-                  <%= f.hidden_field :pad_timings_data, data: { beat_target: "hidden_pad_timings_data_field" } %>
+            <%= turbo_frame_tag "error_messages" do %>
+              <%= render "shared/danger" %>
+            <% end %>
+            <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
+              <div class="px-4 pb-4">
+                <%= f.label :beat_title %>
+                <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 placeholder-gray-500 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50", placeholder: 'Please enter a beat title' %>
+                <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
+                <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
+                <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>
+                <%= f.hidden_field :pad_timings_data, data: { beat_target: "hidden_pad_timings_data_field" } %>
+              </div>
+              <div class="p-4">
+                <div class="flex justify-center">
+                  <%= button_tag 'Save', type: 'button', class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold py-2 px-4 rounded", data: { beat_target: "save_button", action: "click->beat#createTheBeat" } %>
                 </div>
-                <div class="p-4">
-                  <div class="flex justify-center">
-                    <%= button_tag 'Save', type: 'button', class: "shadow-lg bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold py-2 px-4 rounded", data: { beat_target: "save_button", action: "click->beat#createTheBeat" } %>
-                  </div>
-                </div>
-              <% end %>
+              </div>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
## 概要
Turbo Frame Missing Errorというエラーが発生していたので、turbo-frameをformの外に移動してやることで解決しました。

## 起きていたエラー
正常に実行された結果として`beats/mybeats`へ遷移しようとすると、以下のエラーによって処理が上手く出来ませんでした。

```
TurboFrameMissingError: The response (200) did not contain the expected <turbo-frame id="save_beat_form"> and will be ignored. To perform a full page visit instead, set turbo-visit-control to reload.
```

## 期待する動作
1. フォームが`beats#create`へリクエストを行う
2. beats#create内のトランザクションが正常に実行される
3. 正常に実行された結果として`beats/mybeats`へTurbo Driveによって遷移する

## この問題の原因
フォームがTurbo Frameの中に存在していると、フォームのHTTPリクエストには`Turbo-Frame: <turbo frame id>
`というヘッダーが付与され、フォームのレスポンスにはそのidを持つTurbo Frameが期待することになります。

今回のケースでは、**成功時にリダイレクト先の`beats/mybeats`のHTMLがレスポンスとして返されるわけですが、この中にはTurbo Frameを含んでいないのでエラー**になります。

## 修正点
本来の想定だとTurbo Frameは「新規ビート保存処理の失敗時にフォームにエラーのフラッシュメッセージを表示させたい」という目的だったので、**フォームをTurbo Frameを囲むのをやめて、フォームの外でエラーの箇所だけを囲むように修正**しました。

そして、**Turbo Frameに対応するDOMをRails controller内の`turbo_stream.replace(...)`にてTurbo Streamが明示的に置換する**ような処理を加えました。

こうすることで、フォームは成功時にTurbo Driveで画面遷移をし、失敗時に該当のFrame箇所をTurbo Streamによって置換してくれるようになりました。