### PR TITLE
Feature/assign the pad timings and youtube

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -112,6 +112,54 @@ export default class extends Controller {
 
     const data = await response.json()
     this.videoId = data.youtubes_data.video_id
+
+    // pad_timings variables
+
+    const t_start_time = data.pad_timings_data.t_time.split('~')[0] // 00:00:00.0
+    const t_end_time = data.pad_timings_data.t_time.split('~')[1]   // 00:00:00.0
+    const t_start_time_integer = t_start_time.split('.')[0] // 00:00:00
+    const t_start_time_decimal = t_start_time.split('.')[1] // 0
+
+    const y_start_time = data.pad_timings_data.y_time.split('~')[0] // 00:00:00.0
+    const y_end_time = data.pad_timings_data.y_time.split('~')[1]   // 00:00:00.0
+    const y_start_time_integer = y_start_time.split('.')[0] // 00:00:00
+    const y_start_time_decimal = y_start_time.split('.')[1] // 0
+
+    const u_start_time = data.pad_timings_data.u_time.split('~')[0] // 00:00:00.0
+    const u_end_time = data.pad_timings_data.u_time.split('~')[1]   // 00:00:00.0
+    const u_start_time_integer = u_start_time.split('.')[0] // 00:00:00
+    const u_start_time_decimal = u_start_time.split('.')[1] // 0
+
+    const g_start_time = data.pad_timings_data.g_time.split('~')[0] // 00:00:00.0
+    const g_end_time = data.pad_timings_data.g_time.split('~')[1]   // 00:00:00.0
+    const g_start_time_integer = g_start_time.split('.')[0] // 00:00:00
+    const g_start_time_decimal = g_start_time.split('.')[1] // 0
+
+    const h_start_time = data.pad_timings_data.h_time.split('~')[0] // 00:00:00.0
+    const h_end_time = data.pad_timings_data.h_time.split('~')[1]   // 00:00:00.0
+    const h_start_time_integer = h_start_time.split('.')[0] // 00:00:00
+    const h_start_time_decimal = h_start_time.split('.')[1] // 0
+
+    const j_start_time = data.pad_timings_data.j_time.split('~')[0] // 00:00:00.0
+    const j_end_time = data.pad_timings_data.j_time.split('~')[1]   // 00:00:00.0
+    const j_start_time_integer = j_start_time.split('.')[0] // 00:00:00
+    const j_start_time_decimal = j_start_time.split('.')[1] // 0
+
+    const b_start_time = data.pad_timings_data.b_time.split('~')[0] // 00:00:00.0
+    const b_end_time = data.pad_timings_data.b_time.split('~')[1]   // 00:00:00.0
+    const b_start_time_integer = b_start_time.split('.')[0] // 00:00:00
+    const b_start_time_decimal = b_start_time.split('.')[1] // 0
+
+    const n_start_time = data.pad_timings_data.n_time.split('~')[0] // 00:00:00.0
+    const n_end_time = data.pad_timings_data.n_time.split('~')[1]   // 00:00:00.0
+    const n_start_time_integer = n_start_time.split('.')[0] // 00:00:00
+    const n_start_time_decimal = n_start_time.split('.')[1] // 0
+
+    const m_start_time = data.pad_timings_data.m_time.split('~')[0] // 00:00:00.0
+    const m_end_time = data.pad_timings_data.m_time.split('~')[1]   // 00:00:00.0
+    const m_start_time_integer = m_start_time.split('.')[0] // 00:00:00
+    const m_start_time_decimal = m_start_time.split('.')[1] // 0
+
   }
 
   connect() {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -181,6 +181,48 @@ export default class extends Controller {
     // assign the pad timings
     this.t_start_timeTarget.value = t_start_time_integer
     this.t_start_time_decimalTarget.value = t_start_time_decimal
+    this.t_end_timeTarget.value = t_end_time_integer
+    this.t_end_time_decimalTarget.value = t_end_time_decimal
+
+    this.y_start_timeTarget.value = y_start_time_integer
+    this.y_start_time_decimalTarget.value = y_start_time_decimal
+    this.y_end_timeTarget.value = y_end_time_integer
+    this.y_end_time_decimalTarget.value = y_end_time_decimal
+
+    this.u_start_timeTarget.value = u_start_time_integer
+    this.u_start_time_decimalTarget.value = u_start_time_decimal
+    this.u_end_timeTarget.value = u_end_time_integer
+    this.u_end_time_decimalTarget.value = u_end_time_decimal
+
+    this.g_start_timeTarget.value = g_start_time_integer
+    this.g_start_time_decimalTarget.value = g_start_time_decimal
+    this.g_end_timeTarget.value = g_end_time_integer
+    this.g_end_time_decimalTarget.value = g_end_time_decimal
+
+    this.h_start_timeTarget.value = h_start_time_integer
+    this.h_start_time_decimalTarget.value = h_start_time_decimal
+    this.h_end_timeTarget.value = h_end_time_integer
+    this.h_end_time_decimalTarget.value = h_end_time_decimal
+
+    this.j_start_timeTarget.value = j_start_time_integer
+    this.j_start_time_decimalTarget.value = j_start_time_decimal
+    this.j_end_timeTarget.value = j_end_time_integer
+    this.j_end_time_decimalTarget.value = j_end_time_decimal
+
+    this.b_start_timeTarget.value = b_start_time_integer
+    this.b_start_time_decimalTarget.value = b_start_time_decimal
+    this.b_end_timeTarget.value = b_end_time_integer
+    this.b_end_time_decimalTarget.value = b_end_time_decimal
+
+    this.n_start_timeTarget.value = n_start_time_integer
+    this.n_start_time_decimalTarget.value = n_start_time_decimal
+    this.n_end_timeTarget.value = n_end_time_integer
+    this.n_end_time_decimalTarget.value = n_end_time_decimal
+
+    this.m_start_timeTarget.value = m_start_time_integer
+    this.m_start_time_decimalTarget.value = m_start_time_decimal
+    this.m_end_timeTarget.value = m_end_time_integer
+    this.m_end_time_decimalTarget.value = m_end_time_decimal
   }
 
   connect() {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -109,6 +109,7 @@ export default class extends Controller {
     })
 
     const data = await response.json()
+    this.videoId = data.youtubes_data.video_id
   }
 
   connect() {
@@ -130,21 +131,21 @@ export default class extends Controller {
   }
 
   initPlayer() {
-    this.youtube = new YT.Player("player", {
-      height: "390",
-      width: "640",
-      videoId: "a2LFVWBmoiw",
-      playerVars: {
-        playsinline: 1
-      },
-      events: {
-        onReady: (event) => {
-          event.target.setVolume(20)
-          event.target.setPlaybackRate(1.2)
-          event.target.playVideo()
+      this.youtube = new YT.Player("player", {
+        height: "390",
+        width: "640",
+        videoId: document.querySelector('#topIndex') ? "a2LFVWBmoiw" : `${this.videoId}`,
+        playerVars: {
+          playsinline: 1
+        },
+        events: {
+          onReady: (event) => {
+            event.target.setVolume(20)
+            event.target.setPlaybackRate(1.2)
+            event.target.playVideo()
+          }
         }
-      }
-    })
+      })
   }
   
   

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -66,6 +66,8 @@ export default class extends Controller {
 
   async initialize() {
     this.element['youtube'] = this
+
+    // assign the default beat in top/index.html.erb
     
     this.t_start_timeTarget.value = "00:01:08"
     this.t_start_time_decimalTarget.value = "3"

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -64,7 +64,7 @@ export default class extends Controller {
                     beatId: String
   }
 
-  initialize() {
+  async initialize() {
     this.element['youtube'] = this
     
     this.t_start_timeTarget.value = "00:01:08"
@@ -101,6 +101,14 @@ export default class extends Controller {
     if (document.querySelector("#topIndex")) {
       return
     }
+
+    // assign the selected beat in the show.html.erb
+
+    const response = await fetch(`/beats/${this.beatIdValue}.json`, {
+      method: 'GET'
+    })
+
+    const data = await response.json()
   }
 
   connect() {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -97,6 +97,10 @@ export default class extends Controller {
     this.m_start_timeTarget.value = "00:02:56"
     this.m_start_time_decimalTarget.value = "1"
     this.m_end_timeTarget.value = "00:59:10"
+
+    if (document.querySelector("#topIndex")) {
+      return
+    }
   }
 
   connect() {

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -60,6 +60,10 @@ export default class extends Controller {
 
   static outlets = [ "step-sequencer" ]
 
+  static values = {
+                    beatId: String
+  }
+
   initialize() {
     this.element['youtube'] = this
     

--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -119,47 +119,68 @@ export default class extends Controller {
     const t_end_time = data.pad_timings_data.t_time.split('~')[1]   // 00:00:00.0
     const t_start_time_integer = t_start_time.split('.')[0] // 00:00:00
     const t_start_time_decimal = t_start_time.split('.')[1] // 0
+    const t_end_time_integer = t_end_time.split('.')[0] // 00:00:00
+    const t_end_time_decimal = t_end_time.split('.')[1] // 0
 
     const y_start_time = data.pad_timings_data.y_time.split('~')[0] // 00:00:00.0
     const y_end_time = data.pad_timings_data.y_time.split('~')[1]   // 00:00:00.0
     const y_start_time_integer = y_start_time.split('.')[0] // 00:00:00
     const y_start_time_decimal = y_start_time.split('.')[1] // 0
+    const y_end_time_integer = y_end_time.split('.')[0] // 00:00:00
+    const y_end_time_decimal = y_end_time.split('.')[1] // 0
 
     const u_start_time = data.pad_timings_data.u_time.split('~')[0] // 00:00:00.0
     const u_end_time = data.pad_timings_data.u_time.split('~')[1]   // 00:00:00.0
     const u_start_time_integer = u_start_time.split('.')[0] // 00:00:00
     const u_start_time_decimal = u_start_time.split('.')[1] // 0
+    const u_end_time_integer = u_end_time.split('.')[0] // 00:00:00
+    const u_end_time_decimal = u_end_time.split('.')[1]
 
     const g_start_time = data.pad_timings_data.g_time.split('~')[0] // 00:00:00.0
     const g_end_time = data.pad_timings_data.g_time.split('~')[1]   // 00:00:00.0
     const g_start_time_integer = g_start_time.split('.')[0] // 00:00:00
     const g_start_time_decimal = g_start_time.split('.')[1] // 0
+    const g_end_time_integer = g_end_time.split('.')[0] // 00:00:00
+    const g_end_time_decimal = g_end_time.split('.')[1] // 0
 
     const h_start_time = data.pad_timings_data.h_time.split('~')[0] // 00:00:00.0
     const h_end_time = data.pad_timings_data.h_time.split('~')[1]   // 00:00:00.0
     const h_start_time_integer = h_start_time.split('.')[0] // 00:00:00
     const h_start_time_decimal = h_start_time.split('.')[1] // 0
+    const h_end_time_integer = h_end_time.split('.')[0] // 00:00:00
+    const h_end_time_decimal = h_end_time.split('.')[1] // 0
 
     const j_start_time = data.pad_timings_data.j_time.split('~')[0] // 00:00:00.0
     const j_end_time = data.pad_timings_data.j_time.split('~')[1]   // 00:00:00.0
     const j_start_time_integer = j_start_time.split('.')[0] // 00:00:00
     const j_start_time_decimal = j_start_time.split('.')[1] // 0
+    const j_end_time_integer = j_end_time.split('.')[0] // 00:00:00
+    const j_end_time_decimal = j_end_time.split('.')[1] // 0
 
     const b_start_time = data.pad_timings_data.b_time.split('~')[0] // 00:00:00.0
     const b_end_time = data.pad_timings_data.b_time.split('~')[1]   // 00:00:00.0
     const b_start_time_integer = b_start_time.split('.')[0] // 00:00:00
     const b_start_time_decimal = b_start_time.split('.')[1] // 0
+    const b_end_time_integer = b_end_time.split('.')[0] // 00:00:00
+    const b_end_time_decimal = b_end_time.split('.')[1] // 0
 
     const n_start_time = data.pad_timings_data.n_time.split('~')[0] // 00:00:00.0
     const n_end_time = data.pad_timings_data.n_time.split('~')[1]   // 00:00:00.0
     const n_start_time_integer = n_start_time.split('.')[0] // 00:00:00
     const n_start_time_decimal = n_start_time.split('.')[1] // 0
+    const n_end_time_integer = n_end_time.split('.')[0] // 00:00:00
+    const n_end_time_decimal = n_end_time.split('.')[1] // 0
 
     const m_start_time = data.pad_timings_data.m_time.split('~')[0] // 00:00:00.0
     const m_end_time = data.pad_timings_data.m_time.split('~')[1]   // 00:00:00.0
     const m_start_time_integer = m_start_time.split('.')[0] // 00:00:00
     const m_start_time_decimal = m_start_time.split('.')[1] // 0
+    const m_end_time_integer = m_end_time.split('.')[0] // 00:00:00
+    const m_end_time_decimal = m_end_time.split('.')[1] // 0
 
+    // assign the pad timings
+    this.t_start_timeTarget.value = t_start_time_integer
+    this.t_start_time_decimalTarget.value = t_start_time_decimal
   }
 
   connect() {

--- a/app/views/beats/show.html.erb
+++ b/app/views/beats/show.html.erb
@@ -1,3 +1,15 @@
-<div>
-  <%= render 'shared/play_beat' %>
+<div class="hidden md:block">
+  <div id="youtube" data-controller="youtube" data-action="
+    keydown.t@document->youtube#play 
+    keydown.y@document->youtube#play
+    keydown.u@document->youtube#play
+    keydown.g@document->youtube#play
+    keydown.h@document->youtube#play
+    keydown.j@document->youtube#play
+    keydown.b@document->youtube#play
+    keydown.n@document->youtube#play
+    keydown.m@document->youtube#play
+    ">
+    <%= render 'shared/play_beat' %>
+  </div>
 </div>

--- a/app/views/beats/show.html.erb
+++ b/app/views/beats/show.html.erb
@@ -1,5 +1,5 @@
 <div class="hidden md:block">
-  <div id="youtube" data-controller="youtube" data-action="
+  <div id="youtube" data-controller="youtube" data-youtube-beat-id-value="<%= @beat.id %>" data-action="
     keydown.t@document->youtube#play 
     keydown.y@document->youtube#play
     keydown.u@document->youtube#play

--- a/app/views/shared/_play_beat.html.erb
+++ b/app/views/shared/_play_beat.html.erb
@@ -1,47 +1,33 @@
-<div class="hidden md:block">
-  <div id="youtube" data-controller="youtube" data-action="
-    keydown.t@document->youtube#play 
-    keydown.y@document->youtube#play
-    keydown.u@document->youtube#play
-    keydown.g@document->youtube#play
-    keydown.h@document->youtube#play
-    keydown.j@document->youtube#play
-    keydown.b@document->youtube#play
-    keydown.n@document->youtube#play
-    keydown.m@document->youtube#play
-    ">
-    <div class="pt-4">
-      <% flash.each do |type, message| %>
-        <div class="flex items-center justify-center">
-          <% if type == 'notice' %>
-            <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
-              <%= content_tag(:div, message, class: "alert alert-danger") %>
-            </div>
-          <% else %>
-            <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-              <%= content_tag(:div, message, class: "alert alert-success") %>
-            </div>
-          <% end %>
+<div class="pt-4">
+  <% flash.each do |type, message| %>
+    <div class="flex items-center justify-center">
+      <% if type == 'notice' %>
+        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+          <%= content_tag(:div, message, class: "alert alert-danger") %>
+        </div>
+      <% else %>
+        <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+          <%= content_tag(:div, message, class: "alert alert-success") %>
         </div>
       <% end %>
-      <div class="flex justify-center items-center">
-        <div class="p-4">
-          <%= render 'shared/youtube' %>
-        </div>
-        <div>
-          <div>
-            <%= render 'shared/pad_to_set_time' %>
-          </div>
-        </div>
-      </div>
     </div>
-    <hr class="h-px mt-5 bg-gray-200 border-0">
+  <% end %>
+  <div class="flex justify-center items-center">
+    <div class="p-4">
+      <%= render 'shared/youtube' %>
+    </div>
     <div>
       <div>
-        <div>
-          <%= render 'shared/sequencer' %>
-        </div>
+        <%= render 'shared/pad_to_set_time' %>
       </div>
+    </div>
+  </div>
+</div>
+<hr class="h-px mt-5 bg-gray-200 border-0">
+<div>
+  <div>
+    <div>
+      <%= render 'shared/sequencer' %>
     </div>
   </div>
 </div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,3 +1,15 @@
-<div>
-  <%= render 'shared/play_beat' %>
+<div class="hidden md:block">
+  <div id="youtube" data-controller="youtube" data-action="
+    keydown.t@document->youtube#play 
+    keydown.y@document->youtube#play
+    keydown.u@document->youtube#play
+    keydown.g@document->youtube#play
+    keydown.h@document->youtube#play
+    keydown.j@document->youtube#play
+    keydown.b@document->youtube#play
+    keydown.n@document->youtube#play
+    keydown.m@document->youtube#play
+    ">
+    <%= render 'shared/play_beat' %>
+  </div>
 </div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,4 +1,4 @@
-<div class="hidden md:block">
+<div id="topIndex" class="hidden md:block">
   <div id="youtube" data-controller="youtube" data-action="
     keydown.t@document->youtube#play 
     keydown.y@document->youtube#play


### PR DESCRIPTION
## 概要
`beats/mybeats`から選んだビートの`Assign To Play`ボタンをクリックすると、ビート詳細画面に遷移し、そのビートに紐づいたパッドの時間が全てセッティングされるようにしました。

また、Youtubeもそのビートと紐づいたYoutube動画が埋め込まれて表示されるように変更しました。

## 変更点
・`fetch()`で`beats#show`に対してフォーマットをjsonでリクエストを送信する処理を追加
・`fetch()`でのレスポンスのJSONを整形し、値を各パッドの`input`に割り当てる処理を追加
・`initPlayer()`でのYoutubeの動画idを`top/index.html.erb`かそれ以外かで値が変わるような分岐を追加
