### PR TITLE
Fix/playing youtube video error in beats/show.html.erb

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -111,7 +111,6 @@ export default class extends Controller {
     })
 
     const data = await response.json()
-    this.videoId = data.youtubes_data.video_id
 
     // pad_timings variables
 
@@ -225,8 +224,19 @@ export default class extends Controller {
     this.m_end_time_decimalTarget.value = m_end_time_decimal
   }
 
-  connect() {
+  async connect() {
     this.element['youtube'] = this
+
+    if (!document.querySelector('#topIndex')) {
+
+    const response = await fetch(`/beats/${this.beatIdValue}.json`, {
+      method: 'GET'
+    })
+
+    const data = await response.json()
+    this.videoId = await data.youtubes_data.video_id
+
+    }
   
     if (window.YT) {
       this.initPlayer()


### PR DESCRIPTION
## 概要
ビート詳細画面(`beats/show.html.erb`)に遷移した時に、Youtubeの埋め込み動画のエラーが発生しており動画が正常に埋め込まれていなかったため修正をしました。

## 実装したかった内容
`this.videoId`が`initPlayer()`の`videoId:`の値となること

## 問題の原因
`initPlayer()`で動画のインスタンスが生成された後に`this.videoId`に代入をしてしまっていたので、空の`this.videoId`で`initPlayer()`が実行されてしまっていた

## 修正点
`initialize()`の中にある`this.videoId`に代入する処理を`connect()`の`initPlayer()`実行直前のところに移動しました。

そして、`async/await`を用いて`this.videoId`に代入されるのを待ってから`initPlayer()`を実行するように修正しました。