### PR TITLE
Feature/assign the bpm

### DIFF
--- a/app/javascript/controllers/youtube_controller.js
+++ b/app/javascript/controllers/youtube_controller.js
@@ -222,6 +222,10 @@ export default class extends Controller {
     this.m_start_time_decimalTarget.value = m_start_time_decimal
     this.m_end_timeTarget.value = m_end_time_integer
     this.m_end_time_decimalTarget.value = m_end_time_decimal
+
+    // assign the bpm
+    this.stepSequencerOutlet.bpmTarget.value = data.sequencers_data.bpm
+    this.stepSequencerOutlet.current_bpmTarget.textContent = data.sequencers_data.bpm
   }
 
   async connect() {

--- a/app/views/beats/show.html.erb
+++ b/app/views/beats/show.html.erb
@@ -1,5 +1,5 @@
 <div class="hidden md:block">
-  <div id="youtube" data-controller="youtube" data-youtube-beat-id-value="<%= @beat.id %>" data-action="
+  <div id="youtube" data-controller="youtube" data-youtube-beat-id-value="<%= @beat.id %>" data-youtube-step-sequencer-outlet=".step-sequencer" data-action="
     keydown.t@document->youtube#play 
     keydown.y@document->youtube#play
     keydown.u@document->youtube#play

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="step-sequencer" id="step-sequencer">
+<div data-controller="step-sequencer" id="step-sequencer" class="step-sequencer">
   <div class="px-12 py-6 mt-2">
     <div class="mb-4">
       <div class="flex justify-center items-center gap-3">

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,5 +1,5 @@
 <div id="topIndex" class="hidden md:block">
-  <div id="youtube" data-controller="youtube" data-action="
+  <div id="youtube" data-controller="youtube" data-youtube-step-sequencer-outlet=".step-sequencer" data-action="
     keydown.t@document->youtube#play 
     keydown.y@document->youtube#play
     keydown.u@document->youtube#play


### PR DESCRIPTION
## 概要
ビート詳細画面(`beats/show.html.erb`)に遷移した時に、そのビートに紐づいたBPMを画面のシークエンサー箇所に反映するような処理を追加しました。

## 変更点
・`this.stepSequencerOutlet`を使うために取り出すコントローラーの`data-youtube-step-sequencer-outlet=".step-sequencer"`を、取り出される対象に`class="step-sequencer"`を付与しました。

・BPMをDOMによって反映しました