### PR TITLE
Fix/all active index data same as hihats one

### DIFF
--- a/app/javascript/controllers/beat_controller.js
+++ b/app/javascript/controllers/beat_controller.js
@@ -65,8 +65,8 @@ export default class extends Controller {
     })
 
     const hihatsActiveStr = hihatsActiveArray.toString()
-    const snaresActiveStr = hihatsActiveArray.toString()
-    const kicksActiveStr = hihatsActiveArray.toString()
+    const snaresActiveStr = snaresActiveArray.toString()
+    const kicksActiveStr = kicksActiveArray.toString()
 
     // pads_assigned | "T,H,B"
     const padsStepsArray = stepsArray.slice(16,32)


### PR DESCRIPTION
## 概要
データベースの`sequencer`テーブルの`snares_active_index`と`kicks_active_index`が`hihats_active_index`のデータと完全に同じものが保存されてしまっている問題が発生していました。　

原因は、アクティブ化されているパッドのindexの配列を`hihatsActiveStr`, `snaresActiveStr`, `kicksActiveStr`のそれぞれに文字列に変換した上で代入する上で、全ての変数に対して`hihatsActiveArray.toString()`を代入していたことです。

よって、該当箇所をきちんと`hihatsActiveArray.toString()`, `snaresActiveArray.toString()`, `kicksActiveArray.toString()`が代入されるように修正を行いました。