### PR TITLE
Feature/assign volumes

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -114,6 +114,17 @@ export default class extends Controller {
           }
         })
       })
+
+      // assign the volumes
+      const youtubeVolume = data.sequencers_data.youtube_volume
+      const hihatVolume = data.sequencers_data.hihat_volume
+      const snareVolume = data.sequencers_data.snare_volume
+      const kickVolume = data.sequencers_data.kick_volume
+
+      this.pads_volumeTarget.value = youtubeVolume
+      this.hihats_volumeTarget.value = hihatVolume
+      this.snares_volumeTarget.value = snareVolume
+      this.kicks_volumeTarget.value = kickVolume
     }
 
     if (document.querySelector('#topIndex')) {


### PR DESCRIPTION
## 概要
ビート詳細画面(`beats/show.html.erb`)に遷移した時、該当ビートの情報をデータベースより取得して、`youtube_volume`, `hihat_volume`, `snare_volume`, `kick_volume`をそれぞれ各ボリュームの`value`に代入して反映させる処理を追加しました。