### PR TITLE
Feature/destroy the beat

### DIFF
--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -68,9 +68,9 @@ class BeatsController < ApplicationController
   def destroy
     @beat = Beat.find(params[:id])
     if @beat.destroy!
-      redirect_to mybeats_beats_path, status: :see_other, notice: 'the beat is deleted successfully.'
+      redirect_to mybeats_beats_path, status: :see_other, notice: "the beat is deleted successfully."
     else
-      redirect_to mybeats_beats_path, status: :see_other, danger: 'Error: Could not delete the beat.'
+      redirect_to mybeats_beats_path, status: :see_other, danger: "Error: Could not delete the beat."
     end
   end
 

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -68,11 +68,9 @@ class BeatsController < ApplicationController
   def destroy
     @beat = Beat.find(params[:id])
     if @beat.destroy!
-      flash.now[:notice] = 'the beat is deleted successfully.'
-      redirect_to mybeats_beats_path, status: :see_other
+      redirect_to mybeats_beats_path, status: :see_other, notice: 'the beat is deleted successfully.'
     else
-      flash.now[:danger] = 'Error: Could not delete the beat.'
-      redirect_to mybeats_beats_path, status: :see_other
+      redirect_to mybeats_beats_path, status: :see_other, danger: 'Error: Could not delete the beat.'
     end
   end
 

--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -65,6 +65,17 @@ class BeatsController < ApplicationController
     @beats = Beat.where(user_id: current_user.id)
   end
 
+  def destroy
+    @beat = Beat.find(params[:id])
+    if @beat.destroy!
+      flash.now[:notice] = 'the beat is deleted successfully.'
+      redirect_to mybeats_beats_path, status: :see_other
+    else
+      flash.now[:danger] = 'Error: Could not delete the beat.'
+      redirect_to mybeats_beats_path, status: :see_other
+    end
+  end
+
   private
 
   def beat_params

--- a/app/models/beat.rb
+++ b/app/models/beat.rb
@@ -1,8 +1,8 @@
 class Beat < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
 
-  has_one :youtube
-  has_one :pad_timing
-  has_one :sequencer
+  has_one :youtube, dependent: :destroy
+  has_one :pad_timing, dependent: :destroy
+  has_one :sequencer, dependent: :destroy
   belongs_to :user
 end

--- a/app/views/beats/shared/_beat.html.erb
+++ b/app/views/beats/shared/_beat.html.erb
@@ -16,7 +16,7 @@
               <%= button_to "Assign To Play", beat_path(beat.id), method: :get, class: 'px-4 py-2 border border-black rounded-md' %>
             </div>
             <div>
-              <%= button_to "Delete", '#', class: 'px-4 py-2 border border-black rounded-md' %>
+              <%= button_to "Delete", beat_path(beat.id), { method: :delete, data: { confirm: 'Are you sure you want to delete this beat?' },class: 'px-4 py-2 border border-black rounded-md' } %>
             </div>
           </div>
         </div>

--- a/app/views/beats/shared/_beat.html.erb
+++ b/app/views/beats/shared/_beat.html.erb
@@ -16,7 +16,7 @@
               <%= button_to "Assign To Play", beat_path(beat.id), method: :get, class: 'px-4 py-2 border border-black rounded-md' %>
             </div>
             <div>
-              <%= button_to "Delete", beat_path(beat.id), { method: :delete, data: { confirm: 'Are you sure you want to delete this beat?' },class: 'px-4 py-2 border border-black rounded-md' } %>
+              <%= button_to "Delete", beat_path(beat.id), { method: :delete, data: { turbo_method: :delete ,turbo_confirm: 'Are you sure you want to delete this beat?' }, class: 'px-4 py-2 border border-black rounded-md' } %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概要
`beats#destroy`アクションを新規作成し、特定のビートの削除が出来るようにしました。

## 変更点
・`beats#destroy`アクションを新規作成
・`beats#destroy` : 特定のビートの削除を行い、成功時または失敗時にフラッシュメッセージが表示される処理を追加
・ビート一覧画面`/beats/mybeats`の各ビートに削除ボタンを配置（削除ボタンをクリックすると確認メッセージが表示される）

## 確認方法
1. `/beats/mybeats`に遷移する
2. `Delete`ボタンをクリックする
3. 削除の確認メッセージが表示される
4. 確認メッセージの「はい」をクリックする
5. フラッシュメッセージで`the beat is deleted successfully.`と表示されている
6. 削除されたビートがビート一覧画面から消えている