### PR TITLE
[fix] saving the beat when not logged in error

### DIFF
--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -1,5 +1,8 @@
 class BeatsController < ApplicationController
   def create
+    if !user_signed_in?
+      return
+    end
     ActiveRecord::Base.transaction do
       beats_data_json = JSON.parse(beat_params[:beats_data])
       youtubes_data_json = JSON.parse(beat_params[:youtubes_data])

--- a/app/views/shared/beats/_form.html.erb
+++ b/app/views/shared/beats/_form.html.erb
@@ -9,6 +9,14 @@
             <%= turbo_frame_tag "error_messages" do %>
               <%= render "shared/danger" %>
             <% end %>
+            <% if !user_signed_in? %>
+              <div class="flex justify-center items-center p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+                <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+                </svg>
+                <div class="alert alert-danger w-full">You need to login to save the beat.</div>
+              </div>
+            <% end %>
             <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
               <div class="px-4 pb-4">
                 <%= f.label :beat_title %>


### PR DESCRIPTION
## 概要
ログインしていない状態でビートを保存しようとすることを想定しておらず、エラーが発生していたため、ログインしていない状態ではビートを保存することが出来ないように修正しました。

## 変更点
・ログインしていない状態であるなら`beats#create`を実行しないように変更
・ログインしていない状態にビート保存のためのモーダルのフォームを開くと、`You need to login to save the beat.`という警告文が表示されるように変更