### PR TITLE
Fix/access beats actions when not logged in

### DIFF
--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -1,4 +1,6 @@
 class BeatsController < ApplicationController
+  before_action :authenticate_user!
+
   def create
     if !user_signed_in?
       return

--- a/app/views/shared/beats/_form.html.erb
+++ b/app/views/shared/beats/_form.html.erb
@@ -14,7 +14,7 @@
                 <svg class="shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
                 </svg>
-                <div class="alert alert-danger w-full">You need to login to save the beat.</div>
+                <div class="alert font-bold alert-danger w-full">You need to login to save the beat.</div>
               </div>
             <% end %>
             <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>


### PR DESCRIPTION
## 概要
ログインしていない状態のユーザーがbeat controllerのアクションを実行しようとすると予期せぬエラーが発生してしまっていたので、`before_action :authenticate_user!`を`beat_controller.rb`に追加することで、ログインしていない状態のユーザーがbeat_controllerのアクションを実行しようとすると、ログイン画面へ遷移するように修正しました。