### PR TITLE
Feature/update the beat

### DIFF
--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -29,6 +29,29 @@ class BeatsController < ApplicationController
     ), status: :unprocessable_entity
   end
 
+  def update
+    ActiveRecord::Base.transaction do
+      beats_data_json = JSON.parse(beat_params[:beats_data])
+      youtubes_data_json = JSON.parse(beat_params[:youtubes_data])
+      sequencers_data_json = JSON.parse(beat_params[:sequencers_data])
+      pad_timings_data_json = JSON.parse(beat_params[:pad_timings_data])
+
+      @beat =current_user.beats.find(params[:id])
+
+      @beat.update!(beats_data_json)
+      @beat.youtube.update!(youtubes_data_json)
+      @beat.sequencer.update!(sequencers_data_json)
+      @beat.pad_timing.update!(pad_timings_data_json)
+    end
+    redirect_to mybeats_beats_path, notice: "The beat was updated successfully."
+  rescue ActiveRecord::RecordInvalid => e
+    flash.now[:danger] = "The beat could not be updated."
+    render turbo_stream: turbo_stream.replace(
+      "error_messages",
+      render_to_string(partial: "shared/danger")
+    ), status: :unprocessable_entity
+  end
+
   def show
     @beat = Beat.find(params[:id])
     @youtube = @beat.youtube

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -9,15 +9,23 @@
         <input type="range" id="bpm" min="60" max="240" value="94" data-action="input->step-sequencer#currentBPM" data-step-sequencer-target="bpm">
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#playSequencer">Play</button>
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#stopSequencer">Stop</button>
-        <% if current_user.id == @beat.user_id %>
-          <button data-modal-target="SaveThisBeatModal" data-modal-toggle="SaveThisBeatModal" class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded">
-          update this beat
-          </button>
+
+        <% if user_signed_in? %>
+          <% if current_user.id == @beat.user_id %>
+            <button data-modal-target="SaveThisBeatModal" data-modal-toggle="SaveThisBeatModal" class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded">
+            update this beat
+            </button>
+          <% else %>
+            <button data-modal-target="SaveThisBeatModal" data-modal-toggle="SaveThisBeatModal" class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded">
+            save this beat
+            </button>
+          <% end %>
         <% else %>
           <button data-modal-target="SaveThisBeatModal" data-modal-toggle="SaveThisBeatModal" class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded">
           save this beat
           </button>
         <% end %>
+
         <!-- Modal -->
         <%= render 'shared/beats/form', beat: @beat %>
         <!-- Modal toggle -->

--- a/app/views/shared/_sequencer.html.erb
+++ b/app/views/shared/_sequencer.html.erb
@@ -9,9 +9,15 @@
         <input type="range" id="bpm" min="60" max="240" value="94" data-action="input->step-sequencer#currentBPM" data-step-sequencer-target="bpm">
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#playSequencer">Play</button>
         <button class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded" data-action="click->step-sequencer#stopSequencer">Stop</button>
-        <button data-modal-target="SaveThisBeatModal" data-modal-toggle="SaveThisBeatModal" class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded">
-        save this beat
-        </button>
+        <% if current_user.id == @beat.user_id %>
+          <button data-modal-target="SaveThisBeatModal" data-modal-toggle="SaveThisBeatModal" class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded">
+          update this beat
+          </button>
+        <% else %>
+          <button data-modal-target="SaveThisBeatModal" data-modal-toggle="SaveThisBeatModal" class="shadow-lg bg-blue-500 text-white font-bold py-2 px-4 rounded">
+          save this beat
+          </button>
+        <% end %>
         <!-- Modal -->
         <%= render 'shared/beats/form', beat: @beat %>
         <!-- Modal toggle -->

--- a/app/views/shared/beats/_form.html.erb
+++ b/app/views/shared/beats/_form.html.erb
@@ -17,7 +17,7 @@
                 <div class="alert font-bold alert-danger w-full">You need to login to save the beat.</div>
               </div>
             <% end %>
-            <%= form_with model: @beat, url: beats_path, method: :post, data: { beat_target: "beat_save_form" } do |f| %>
+            <%= form_with model: @beat, data: { beat_target: "beat_save_form" } do |f| %>
               <div class="px-4 pb-4">
                 <%= f.label :beat_title %>
                 <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 placeholder-gray-500 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50", placeholder: 'Please enter a beat title' %>

--- a/app/views/shared/beats/_form.html.erb
+++ b/app/views/shared/beats/_form.html.erb
@@ -20,7 +20,7 @@
             <%= form_with model: @beat, data: { beat_target: "beat_save_form" } do |f| %>
               <div class="px-4 pb-4">
                 <%= f.label :beat_title %>
-                <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 placeholder-gray-500 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50", placeholder: 'Please enter a beat title' %>
+                <%= f.text_field :beat_title, class: "ignore-keydown bg-gray-50 border border-gray-300 text-gray-900 placeholder-gray-500 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5", data: { beat_target: "beat_title_field", youtube_target: "beat_title", action: "input->beat#validateBeatTitleInput"}, maxlength: "50", placeholder: 'Please enter a beat title', value: @beat.title %>
                 <%= f.hidden_field :beats_data, data: { beat_target: "hidden_beats_data_field" } %>
                 <%= f.hidden_field :youtubes_data, data: { beat_target: "hidden_youtubes_data_field" } %>
                 <%= f.hidden_field :sequencers_data, data: { beat_target: "hidden_sequencers_data_field" } %>


### PR DESCRIPTION
## 概要
ビートをアップデートできる機能を追加しました。

## 変更点
・`form_with`が`beats#create`にしか処理がいかないようになっていたので、url, methodの指定を消すことで`form_with`が`beats#create`か`beats#update`のどちらに処理を送るかを自動で判断できるように変更しました。
・ビート詳細画面からフォームを開いた場合に、ビートタイトルが入力される`text_field`にビートタイトルが入力されている状態にするように`value: @beat.title`を追加
・`beats#update`を新規作成し、ビートの更新処理を追加