### PR TITLE
[fix] beat info in the each beat is all the same

### DIFF
--- a/app/views/beats/shared/_beat.html.erb
+++ b/app/views/beats/shared/_beat.html.erb
@@ -7,12 +7,12 @@
             <h2 class="font-bold text-lg">🎵 <%= beat.title %></h2>
             <div class="flex items-center">
               <div class="text-sm text-gray-500 mr-1">by</div>
-              <a href="#" class="text-blue-600 hover:underline">test</a>
+              <a href="#" class="text-blue-600 hover:underline"><%= beat.user.username %></a>
             </div>
           </div>
           <div class="text-sm text-gray-700">
-            <p><strong>Youtube:</strong> Bill Evans - My Foolish Heart</p>
-            <p><strong>BPM:</strong> 94</p>
+            <p><strong>Youtube:</strong> <%= beat.youtube.video_title %></p>
+            <p><strong>BPM:</strong> <%= beat.sequencer.bpm %></p>
           </div>
         </div>
         <div class="mx-4">


### PR DESCRIPTION
## 概要
`Public Beats`, `My Beats`のビート一覧画面において、各ビートの情報が全て同一の文字列が静的に表示されていたので、動的に各ビートの情報が表示されるような処理に変更しました。

## 原因
ビートの情報を文字列で入力してしまって、それを繰り返し処理していたので、全てのビートが同一の文字列が表示されていた。

## 解決方法
`<%= %>`の中で受け取ったbeatの情報から動的に値を表示する処理に変更した。