### PR TITLE
Fix/drum sounds still persist after page change

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -196,6 +196,9 @@ export default class extends Controller {
     this.hihatGain.gain.value = this.hihats_volumeTarget.value
     this.snareGain.gain.value = this.snares_volumeTarget.value
     this.kickGain.gain.value = this.kicks_volumeTarget.value
+
+    // stop the sequencer when the page is changed
+    window.addEventListener(('beforeunload', this.stopSequencer()))
   }
 
   setTheDataToSave () {


### PR DESCRIPTION
## 概要
`Play`ボタンを押してシーケンサーを再生した状態で他のページに遷移すると、ドラムの音声が残り続ける不具合を修正しました。

## 原因
Tone.jsでシーケンサーを再生した場合、シーケンサーを止める処理を実行してあげないといつまでも音が鳴り続ける。

## 解決方法
`connect()`の中で、ページを離れる時に`stopSequencer()`が発火するようなイベントリスナーを追加することで、他のページに遷移しようとした時に、遷移する直前にシーケンサーの再生を停止してから遷移するように修正しました。

`stopSequencer()`はシーケンサーを中止するために用意していたメソッドです。