### PR TITLE
[fix] the drums sounds still parsist after the page is changed with turbo

### DIFF
--- a/app/javascript/controllers/step_sequencer_controller.js
+++ b/app/javascript/controllers/step_sequencer_controller.js
@@ -25,8 +25,17 @@ export default class extends Controller {
   }
 
   async initialize() {
-    console.log(this.beatIdValue)
     this.loopId = null
+
+    // stop the sequencer when the page is changed
+    window.addEventListener('beforeunload', (event) => {
+      this.stopSequencer()
+    })
+
+    // stop the sequencer when the page is changed with turbo
+    window.addEventListener("turbo:before-cache", () => {
+      this.stopSequencer()
+    })
 
     this._inactiveFirstStepBgColor = 'bg-gray-400'
     this._activeStepBgColor = 'bg-green-300'


### PR DESCRIPTION
## 概要
Turboで画面遷移を行った時に、ドラムの音声が継続して鳴り続けてしまう不具合を修正しました。

## 原因
`addEventListener`にて`beforeunload`を発火の条件としていましたが、Turboで遷移した時には`beforeunload`が発火しないようです。

## 解決方法
`turbo:before-cache`を発火の条件とする`addEventListener`を追加することで、Turboで画面遷移する時に`stopSequencer()`が実行されるように修正しました。