### PR TITLE
Fix/deletable the other user beat

### DIFF
--- a/app/controllers/beats_controller.rb
+++ b/app/controllers/beats_controller.rb
@@ -99,6 +99,7 @@ class BeatsController < ApplicationController
 
   def destroy
     @beat = Beat.find(params[:id])
+    return if !user_signed_in? || @beat.user_id != current_user.id
     if @beat.destroy!
       redirect_to mybeats_beats_path, status: :see_other, notice: "the beat is deleted successfully."
     else

--- a/app/views/beats/shared/_beat.html.erb
+++ b/app/views/beats/shared/_beat.html.erb
@@ -22,11 +22,13 @@
             </div>
             Assign to Play
           <% end %>
-          <%= button_to beat_path(beat.id), method: :delete ,class: "flex justify-center bg-red-500 text-white w-full text-sm px-4 py-3 mb-5 rounded hover:bg-red-600 flex items-center" do %>
-            <div class="mr-1">
-              <i class="fa fa-trash-o"></i>
-            </div>
-            Delete
+          <% if user_signed_in? && current_user.id == beat.user_id %>
+            <%= button_to beat_path(beat.id), method: :delete ,class: "flex justify-center bg-red-500 text-white w-full text-sm px-4 py-3 mb-5 rounded hover:bg-red-600 flex items-center" do %>
+              <div class="mr-1">
+                <i class="fa fa-trash-o"></i>
+              </div>
+              Delete
+            <% end %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
## 不具合
ユーザーが、他のユーザーの作成したビートを削除できる状態になっていた。

## 解決
・ユーザーがログインしていない場合は、削除ボタンが全て表示されないように修正しました
・ユーザーがログインしている場合は、他の人のビートの削除ボタンが表示されないように修正しました
・他の人のビートを削除しようと試みたときに、`beats#destroy`アクションが実行されずに中断されるように修正しました